### PR TITLE
GPX-212 bke naming

### DIFF
--- a/bke-runtime/gp-bke-runtime-minimal-application/README.md
+++ b/bke-runtime/gp-bke-runtime-minimal-application/README.md
@@ -8,6 +8,14 @@ This Helm-Chart generates a Deployment with the configured Image (Variable 'imag
 ```oc new-project example-dev```  
 ```helm install example-app gp-helm-charts/gp-bke-deploy-app -f example-app-values.yaml -n example-dev```
 
+## Alternative Usage
+
+### Set values on Command Line
+```helm install nginx-bke-test gepaplexx/gp-bke-runtime-minimal-application -n example-dev --set image.name=bitnami/nginx --set image.tag=latest --set route.enabled=true```
+
+### Use local (this) chart directory
+```helm install nginx-bke-test . -n example-dev --set image.name=bitnami/nginx --set image.tag=latest --set route.enabled=true```
+
 ## values.yaml
 
 ```yaml

--- a/bke-runtime/gp-bke-runtime-minimal-application/README.md
+++ b/bke-runtime/gp-bke-runtime-minimal-application/README.md
@@ -16,6 +16,9 @@ This Helm-Chart generates a Deployment with the configured Image (Variable 'imag
 ### Use local (this) chart directory
 ```helm install nginx-bke-test . -n example-dev --set image.name=bitnami/nginx --set image.tag=latest --set route.enabled=true```
 
+### Use a different name for the application an for the chart
+```helm install nginx-bke-test . -n example-dev --set image.name=bitnami/nginx --set image.tag=latest --set route.enabled=true --set nameOverride=proxy```
+
 ## values.yaml
 
 ```yaml

--- a/bke-runtime/gp-bke-runtime-minimal-application/templates/_helpers.tpl
+++ b/bke-runtime/gp-bke-runtime-minimal-application/templates/_helpers.tpl
@@ -1,26 +1,20 @@
 {{/*
-Expand the name of the chart.
+Create names of the appliacation
 */}}
-{{- define "gp-bke-runtime-minimal-application.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- define "gp-bke-runtime-minimal-application.logical.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "gp-bke-runtime-minimal-application.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- define "gp-bke-runtime-minimal-application.technical.name" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "gp-bke-runtime-minimal-application.service.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "gp-bke-runtime-minimal-application.route.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 54 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -46,44 +40,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "gp-bke-runtime-minimal-application.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "gp-bke-runtime-minimal-application.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "gp-bke-runtime-minimal-application.technical.name" . }}
+app.kubernetes.io/instance: {{ include "gp-bke-runtime-minimal-application.logical.name" . }}
 {{- end }}
 
-{{- define "gp-bke-runtime-minimal-application.route.name" -}}
-{{- if .Values.fullnameOverride -}}
-{{- "rt-" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- "rt-" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "rt-%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "gp-bke-runtime-minimal-application.service.name" -}}
-{{- if .Values.fullnameOverride -}}
-{{- "svc-" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- "svc-" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "svc-%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "gp-bke-runtime-minimal-application.route.hostname" -}}
-{{- if .Values.route.basename -}}
-{{- if .Values.route.hostname -}}
-{{- printf "%s.%s.%s" .Values.route.hostname .Release.Namespace .Values.route.basename -}}
-{{- else -}}
-{{- printf "%s.%s.%s" .Release.Name .Release.Namespace .Values.route.basename -}}
-{{- end -}}
-{{- else -}}
-{{- printf "" -}}
-{{- end -}}
-{{- end -}}

--- a/bke-runtime/gp-bke-runtime-minimal-application/templates/_helpers.tpl
+++ b/bke-runtime/gp-bke-runtime-minimal-application/templates/_helpers.tpl
@@ -1,28 +1,34 @@
 {{/*
-Create names of the appliacation
+Expand the name of the chart.
 */}}
-{{- define "gp-bke-runtime-minimal-application.logical.name" -}}
-{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "gp-bke-runtime-minimal-application.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
-{{- define "gp-bke-runtime-minimal-application.technical.name" -}}
-{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "gp-bke-runtime-minimal-application.service.name" -}}
-{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "gp-bke-runtime-minimal-application.route.name" -}}
-{{- default .Release.Name .Values.nameOverride | trunc 54 | trimSuffix "-" -}}
-{{- end -}}
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gp-bke-runtime-minimal-application.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "gp-bke-runtime-minimal-application.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Common labels
@@ -40,7 +46,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "gp-bke-runtime-minimal-application.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "gp-bke-runtime-minimal-application.technical.name" . }}
-app.kubernetes.io/instance: {{ include "gp-bke-runtime-minimal-application.logical.name" . }}
+app.kubernetes.io/name: {{ include "gp-bke-runtime-minimal-application.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gp-bke-runtime-minimal-application.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gp-bke-runtime-minimal-application.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/bke-runtime/gp-bke-runtime-minimal-application/templates/_helpers_pg.tpl
+++ b/bke-runtime/gp-bke-runtime-minimal-application/templates/_helpers_pg.tpl
@@ -1,0 +1,19 @@
+{{/*
+Create names of the appliacation
+*/}}
+{{- define "gp-bke-runtime-minimal-application.logical.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "gp-bke-runtime-minimal-application.technical.name" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "gp-bke-runtime-minimal-application.service.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "gp-bke-runtime-minimal-application.route.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 54 | trimSuffix "-" -}}
+{{- end -}}
+

--- a/bke-runtime/gp-bke-runtime-minimal-application/templates/deployment.yaml
+++ b/bke-runtime/gp-bke-runtime-minimal-application/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "gp-bke-runtime-minimal-application.fullname" . }}
+  name: {{ include "gp-bke-runtime-minimal-application.logical.name" . }}
   labels:
     {{- include "gp-bke-runtime-minimal-application.labels" . | nindent 4 }}
 spec:

--- a/bke-runtime/gp-bke-runtime-minimal-application/templates/route.yml
+++ b/bke-runtime/gp-bke-runtime-minimal-application/templates/route.yml
@@ -10,7 +10,7 @@ spec:
     targetPort: http
   to:
     kind: Service
-    name: svc-{{ include "gp-bke-runtime-minimal-application.fullname" . }}
+    name: {{ include "gp-bke-runtime-minimal-application.service.name" . }}
     weight: 100
 {{- if .Values.route.hostnameOverride }}
 {{- if .Values.route.basename }}

--- a/bke-runtime/gp-bke-runtime-minimal-application/templates/route.yml
+++ b/bke-runtime/gp-bke-runtime-minimal-application/templates/route.yml
@@ -12,11 +12,6 @@ spec:
     kind: Service
     name: {{ include "gp-bke-runtime-minimal-application.service.name" . }}
     weight: 100
-{{- if .Values.route.hostnameOverride }}
-{{- if .Values.route.basename }}
-  hostname: {{ include "gp-bke-runtime-minimal-application.route.hostname" . }}
-{{- end }}
-{{- end }}
   wildcardPolicy: {{ .Values.route.wildcardPolicy }}
 {{- if .Values.route.tls.enabled }}
   tls:

--- a/bke-runtime/gp-bke-runtime-minimal-application/templates/service.yaml
+++ b/bke-runtime/gp-bke-runtime-minimal-application/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: svc-{{ include "gp-bke-runtime-minimal-application.fullname" . }}
+  name: {{ include "gp-bke-runtime-minimal-application.service.name" . }}
   labels:
     {{- include "gp-bke-runtime-minimal-application.labels" . | nindent 4 }}
 spec:

--- a/bke-runtime/gp-bke-runtime-minimal-application/values.yaml
+++ b/bke-runtime/gp-bke-runtime-minimal-application/values.yaml
@@ -35,10 +35,6 @@ service:
 route:
   # Deploy a route for this deployment?
   enabled: false
-  # whether you want to explicitely set a hostname. if true, requires route.basename
-  hostnameOverride: false
-  # route.hostname if not defined and route.hostnameOverride .Release.Name will be applied
-  # route.basename: apps.play.geplexx.com
   wildcardPolicy: None
   tls:
     enabled: true


### PR DESCRIPTION
Es geht um gp-bke-runtime-minimal-application.
Das vorhandene `_helpers.tpl` war relativ komplex, mit viel Konfigurationsmöglichkeiten die teilweise nicht funktioniert haben. Ich habe es daher mal fast auf minimal zusammengestrichen und die Namen vereinheitlicht/vereinfacht. Die Idee dahinter:

- Die Servicename und Route-Namen sollten keine internen technischen Bezüge haben (BKE-Name), da sie von außen oder anderen Komponenten ansprechbar sein sollen. Sollten rein fachlich motiviert sein.
- Die Helm-Charts haben eher einen technischen Bezug und sind eventuell nicht auf einen Namespace beschränkt(?)
- Daher: Namen sind per Default _Release.Name_ aber mit _nameOverride_ (gefällt mir nicht sonderlich) überschreibbar.
- Prefix `svc-` habe ich weggelassen (`i-count` für Variablenbenennung hatten wir noch in COBOL, ist aber tendenziell schlechte Praxis) weil dem Aufrufer z.B. bei einem Webservice egal ist, ob das ein Pod, Ein Service oder ein externer Host ist. 