### PR TITLE
GPX-232 allow wider range for limits

### DIFF
--- a/infra/gp-cluster-config/values.yaml
+++ b/infra/gp-cluster-config/values.yaml
@@ -10,11 +10,11 @@ resourceQuota:
 
 limitRange:
   default:
-    cpu: 100m
-    memory: 500Mi
+    cpu: 300m
+    memory: 2Gi
   defaultRequest:
     cpu: 25m
-    memory: 250Mi
+    memory: 128Mi
 
 alertmanager:
   config:


### PR DESCRIPTION
MySQL deployed nicht mit <200Mi, daher am Play Cluster angepasst und hier nachgezogen.