### PR TITLE
start cluster update at 3 UTC instead of 5 UTC

### DIFF
--- a/infra/gp-cluster-update-checker/values.yaml
+++ b/infra/gp-cluster-update-checker/values.yaml
@@ -15,7 +15,7 @@ checker:
       cpu: "10m"
 
 updater:
-  schedule: '"0 5 * * 2-5"'
+  schedule: '"0 3 * * 2-5"'
   successfulJobsHistoryLimit: 2
   suspend: true
   delay: 1


### PR DESCRIPTION
Da der Kubernetes Schedule in UTC ist und nicht in unserer Zeit startet das Update im Winter um 6 bzw. Sommer um 7 Uhr. 
Auf Kundencluster kann es allerdings vorkommen, dass zu diesem Zeitpunkt schon mit dem Cluster gearbeitet wird und dieser aufgrund des Updates langsamer reagiert. 