### PR TITLE
GPX-276 - Events persistieren

### DIFF
--- a/day-2-operations/gp-cluster-setup/values.yaml
+++ b/day-2-operations/gp-cluster-setup/values.yaml
@@ -215,6 +215,23 @@ applications:
         prune: true
         selfHeal: true
 
+####################### CLUSTER-LOGGING-EVENTROUTER #######################
+  clusterLoggingEventrouter:
+    name: cluster-logging-eventrouter
+    enabled: true
+    destination:
+      namespace: openshift-logging
+      create: true
+    argoProject: gepaplexx
+    source:
+      repoURL: "https://gepaplexx.github.io/gp-helm-charts/"
+      chart: gp-cluster-logging-eventrouter
+      targetRevision: "*"
+    syncPolicy:
+      automated:
+        prune: true
+        selfHeal: true
+
 ##################### CLUSTER-MONITORING ######################
   clusterMonitoring:
     name: cluster-monitoring

--- a/day-2-operations/gp-cluster-setup/values/values-play.yaml
+++ b/day-2-operations/gp-cluster-setup/values/values-play.yaml
@@ -235,6 +235,23 @@ applications:
         prune: true
         selfHeal: true
 
+####################### CLUSTER-LOGGING-EVENTROUTER #######################
+  clusterLoggingEventrouter:
+    name: cluster-logging-eventrouter
+    enabled: true
+    destination:
+      namespace: openshift-logging
+      create: true
+    argoProject: gepaplexx
+    source:
+      repoURL: "https://gepaplexx.github.io/gp-helm-charts/"
+      chart: gp-cluster-logging-eventrouter
+      targetRevision: "*"
+    syncPolicy:
+      automated:
+        prune: true
+        selfHeal: true
+
 ##################### CLUSTER-MONITORING ######################
   clusterMonitoring:
     name: cluster-monitoring

--- a/day-2-operations/gp-cluster-setup/values/values-prod.yaml
+++ b/day-2-operations/gp-cluster-setup/values/values-prod.yaml
@@ -241,6 +241,23 @@ applications:
         prune: true
         selfHeal: true
 
+####################### CLUSTER-LOGGING-EVENTROUTER #######################
+  clusterLoggingEventrouter:
+    name: cluster-logging-eventrouter
+    enabled: true
+    destination:
+      namespace: openshift-logging
+      create: true
+    argoProject: gepaplexx
+    source:
+      repoURL: "https://gepaplexx.github.io/gp-helm-charts/"
+      chart: gp-cluster-logging-eventrouter
+      targetRevision: "*"
+    syncPolicy:
+      automated:
+        prune: true
+        selfHeal: true
+
 ##################### CLUSTER-MONITORING ######################
   clusterMonitoring:
     name: cluster-monitoring

--- a/day-2-operations/gp-cluster-setup/values/values-steppe.yaml
+++ b/day-2-operations/gp-cluster-setup/values/values-steppe.yaml
@@ -240,6 +240,23 @@ applications:
         prune: true
         selfHeal: true
 
+####################### CLUSTER-LOGGING-EVENTROUTER #######################
+  clusterLoggingEventrouter:
+    name: cluster-logging-eventrouter
+    enabled: true
+    destination:
+      namespace: openshift-logging
+      create: true
+    argoProject: gepaplexx
+    source:
+      repoURL: "https://gepaplexx.github.io/gp-helm-charts/"
+      chart: gp-cluster-logging-eventrouter
+      targetRevision: "*"
+    syncPolicy:
+      automated:
+        prune: true
+        selfHeal: true
+
 ##################### CLUSTER-MONITORING ######################
   clusterMonitoring:
     name: cluster-monitoring

--- a/infra/gp-cluster-logging-eventrouter/.helmignore
+++ b/infra/gp-cluster-logging-eventrouter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infra/gp-cluster-logging-eventrouter/Chart.yaml
+++ b/infra/gp-cluster-logging-eventrouter/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: gp-cluster-logging-eventrouter
+description: Adds a Pod which logs all events from all projects. See https://docs.openshift.com/container-platform/4.10/logging/cluster-logging-eventrouter.html
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.3"

--- a/infra/gp-cluster-logging-eventrouter/templates/clusterrole.yaml
+++ b/infra/gp-cluster-logging-eventrouter/templates/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.clusterRole.name }}
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - get
+    - watch
+    - list

--- a/infra/gp-cluster-logging-eventrouter/templates/clusterrolebinding.yaml
+++ b/infra/gp-cluster-logging-eventrouter/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.clusterRole.name }}-binding
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.clusterRole.name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/infra/gp-cluster-logging-eventrouter/templates/clusterrolebinding.yaml
+++ b/infra/gp-cluster-logging-eventrouter/templates/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ .Values.clusterRole.name }}

--- a/infra/gp-cluster-logging-eventrouter/templates/configmap.yaml
+++ b/infra/gp-cluster-logging-eventrouter/templates/configmap.yaml
@@ -2,7 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.namespace }}
 data:
   config.json: |-
     {

--- a/infra/gp-cluster-logging-eventrouter/templates/configmap.yaml
+++ b/infra/gp-cluster-logging-eventrouter/templates/configmap.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.namespace }}
+data:
+  config.json: |-
+    {
+      "sink": "stdout"
+    }

--- a/infra/gp-cluster-logging-eventrouter/templates/deployment.yaml
+++ b/infra/gp-cluster-logging-eventrouter/templates/deployment.yaml
@@ -2,7 +2,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.namespace }}
   labels:
     component: "{{ .Release.Name }}"
     logging-infra: "{{ .Release.Name }}"

--- a/infra/gp-cluster-logging-eventrouter/templates/deployment.yaml
+++ b/infra/gp-cluster-logging-eventrouter/templates/deployment.yaml
@@ -31,9 +31,6 @@ spec:
             requests:
               cpu: "{{ .Values.resources.requests.cpu }}"
               memory: "{{ .Values.resources.requests.memory }}"
-            limits:
-              cpu: "{{ .Values.resources.limits.cpu }}"
-              memory: "{{ .Values.resources.limits.memory }}"
           volumeMounts:
             - name: config-volume
               mountPath: /etc/eventrouter

--- a/infra/gp-cluster-logging-eventrouter/templates/deployment.yaml
+++ b/infra/gp-cluster-logging-eventrouter/templates/deployment.yaml
@@ -1,0 +1,43 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    component: "{{ .Release.Name }}"
+    logging-infra: "{{ .Release.Name }}"
+    provider: "openshift"
+spec:
+  selector:
+    matchLabels:
+      component: "{{ .Release.Name }}"
+      logging-infra: "{{ .Release.Name }}"
+      provider: "openshift"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: "{{ .Release.Name }}"
+        logging-infra: "{{ .Release.Name }}"
+        provider: "openshift"
+      name: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      containers:
+        - name: kube-eventrouter
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            requests:
+              cpu: "{{ .Values.resources.requests.cpu }}"
+              memory: "{{ .Values.resources.requests.memory }}"
+            limits:
+              cpu: "{{ .Values.resources.limits.cpu }}"
+              memory: "{{ .Values.resources.limits.memory }}"
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/eventrouter
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ .Release.Name }}

--- a/infra/gp-cluster-logging-eventrouter/templates/serviceaccount.yaml
+++ b/infra/gp-cluster-logging-eventrouter/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.namespace }}
+

--- a/infra/gp-cluster-logging-eventrouter/templates/serviceaccount.yaml
+++ b/infra/gp-cluster-logging-eventrouter/templates/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.namespace }}
 

--- a/infra/gp-cluster-logging-eventrouter/values.yaml
+++ b/infra/gp-cluster-logging-eventrouter/values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: registry.redhat.io/openshift-logging/eventrouter-rhel8
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+namespace: "openshift-logging"
+
+clusterRole:
+  name: "event-reader"
+
+resources:
+   limits:
+     cpu: 100m
+     memory: 128Mi
+   requests:
+     cpu: 100m
+     memory: 128Mi

--- a/infra/gp-cluster-logging-eventrouter/values.yaml
+++ b/infra/gp-cluster-logging-eventrouter/values.yaml
@@ -8,9 +8,6 @@ clusterRole:
   name: "event-reader"
 
 resources:
-   limits:
-     cpu: 100m
-     memory: 128Mi
    requests:
      cpu: 100m
      memory: 128Mi

--- a/infra/gp-cluster-logging-eventrouter/values.yaml
+++ b/infra/gp-cluster-logging-eventrouter/values.yaml
@@ -4,8 +4,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-namespace: "openshift-logging"
-
 clusterRole:
   name: "event-reader"
 


### PR DESCRIPTION
Im openshift-logging namespace wird ein pod gestartet der auf stdout die events aller namespaces loggt.

vor dem merge muss die manuelle installation über helm entfernt werden.