### PR TITLE
GPX-319 VolumesnapshotClass bei Ceph installation hinzufugen

### DIFF
--- a/infra/gp-storage-cephcluster/Chart.yaml
+++ b/infra/gp-storage-cephcluster/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/gp-storage-cephcluster/templates/06-volumesnapshotclass.yaml
+++ b/infra/gp-storage-cephcluster/templates/06-volumesnapshotclass.yaml
@@ -1,0 +1,12 @@
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: {{ .Values.volumeSnapshotClass.deletionPolicy }}
+driver: rook-ceph.rbd.csi.ceph.com
+kind: VolumeSnapshotClass
+metadata:
+  annotations:
+    k10.kasten.io/is-snapshot-class: "true"
+  name: {{ .Values.volumeSnapshotClass.name }}
+parameters:
+  clusterID: rook-ceph
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: {{ .Release.Namespace }}

--- a/infra/gp-storage-cephcluster/values.yaml
+++ b/infra/gp-storage-cephcluster/values.yaml
@@ -48,6 +48,10 @@ storageclassFs:
   name: rook-ceph-fs
   reclaimPolicy: Delete
 
+volumeSnapshotClass:
+  name: rook-ceph-snapshot
+  deletionPolicy: Delete
+
 # OBJECTSTORE
 cephobjectstore:
   enabled: false


### PR DESCRIPTION
Retention Policy Delete, weil: Snapshots auf ein externes Storage-Backup exportiert werden und im Cluster sowieso gelöscht werden sollen nach dem Export. 