### PR TITLE
GPX-321 Kasten Refactoring Authentication

### DIFF
--- a/day-2-operations/gp-cluster-setup/values.yaml
+++ b/day-2-operations/gp-cluster-setup/values.yaml
@@ -514,10 +514,6 @@ applications:
       repoURL: "https://gepaplexx.github.io/gp-helm-charts/"
       targetRevision: "*"
       chart: "gp-kasten-operator"
-      helm:
-        parameters:
-          - name: "kasten.route.host"
-            value: "kasten.apps.example.gepaplexx.com"
     syncPolicy:
       automated:
         prune: true
@@ -543,6 +539,10 @@ applications:
             value: "kasten.apps.${CLUSTERNAME}.gepaplexx.com"
           - name: "kasten.clusterName"
             value: "${CLUSTERNAME}"
+    ignoreDifferences:
+      - jsonPointers:
+          - /spec/auth/openshift/clientSecret
+        kind: K10
     syncPolicy:
       automated:
         prune: true

--- a/day-2-operations/gp-cluster-setup/values/values-steppe.yaml
+++ b/day-2-operations/gp-cluster-setup/values/values-steppe.yaml
@@ -590,10 +590,6 @@ applications:
       repoURL: "https://gepaplexx.github.io/gp-helm-charts/"
       targetRevision: "*"
       chart: "gp-kasten-operator"
-      helm:
-        parameters:
-          - name: "kasten.route.host"
-            value: "kasten.apps.steppe.gepaplexx.com"
     syncPolicy:
       automated:
         prune: true
@@ -619,6 +615,10 @@ applications:
             value: "kasten.apps.steppe.gepaplexx.com"
           - name: "kasten.clusterName"
             value: "steppe"
+    ignoreDifferences:
+      - jsonPointers:
+          - /spec/auth/openshift/clientSecret
+        kind: K10
     syncPolicy:
       automated:
         prune: true

--- a/infra/gp-kasten-instance/templates/03-serviceaccount.yaml
+++ b/infra/gp-kasten-instance/templates/03-serviceaccount.yaml
@@ -3,5 +3,5 @@ kind: ServiceAccount
 metadata:
   annotations:
     serviceaccounts.openshift.io/oauth-redirecturi.dex: https://{{ .Values.kasten.route.host }}/k10-instance/dex/callback
-  name: {{ .Values.kasten.auth.serviceAccount.name }}
+  name: {{ .Values.kasten.auth.serviceAccountName }}
   namespace: {{ .Release.Namespace }}

--- a/infra/gp-kasten-operator/values.yaml
+++ b/infra/gp-kasten-operator/values.yaml
@@ -1,6 +1,0 @@
-kasten:
-  route:
-    host: "kasten.apps.example.gepaplexx.com"
-  auth:
-    serviceAccount:
-      name: "kasten-dex-sa"


### PR DESCRIPTION
helm lookup doesn't work in combination with ArgoCD.
Workaround is to ignoreDifference in this section in spec and add the required by hand.

Dokumentation: https://gepardec.atlassian.net/wiki/spaces/G/pages/2429550593/Kasten
Doku IgnoreDifferences: https://tost.dev/blog/ignore_differences_in_argocd/