### PR TITLE
fix Sonarqube Aufruf in Maven-Build

### DIFF
--- a/bke-development/gp-cicd-sonarqube/Chart.yaml
+++ b/bke-development/gp-cicd-sonarqube/Chart.yaml
@@ -3,7 +3,7 @@ name: gp-cicd-sonarqube
 description: A Helm chart for deploying SonarQube Nexus for static code analysis.
 
 type: application
-version: 0.1.15
+version: 0.1.16
 appVersion: 9.4.0
 
 dependencies:

--- a/bke-development/gp-cicd-sonarqube/values.yaml
+++ b/bke-development/gp-cicd-sonarqube/values.yaml
@@ -69,7 +69,7 @@ sonarqube:
         - '-openshift-ca=/etc/pki/tls/cert.pem'
         - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
         - '-openshift-ca=/etc/sonarqube-configmaps/ocp-injected-certs/ca-bundle.crt'
-        - '-skip-auth-regex=^/metrics'
+        - '-skip-auth-regex=(^/metrics|^/batch|^/api)'
       image: 'quay.io/openshift/origin-oauth-proxy'
       name: sonarqube-proxy
       ports:


### PR DESCRIPTION
Maven Sonar-Plugin verwendet die Pfade /batch und /api. Da wir keine Möglichkeit haben über den Source Code eine OpenShift Authentication durchzuführen, müssen die beiden Pfade im Proxy ausgenommen werden. 

Die Authentifizierung, ob ein Projekt analysiert werden kann oder nicht erfolgt über den sonar.login token.

Signed-off-by: fhochleitner <felix.hochleitner@outlook.com>