### PR TITLE
GPX-177 - rook-ceph metriken sollen im platform prometheus landen

### DIFF
--- a/infra/gp-cluster-monitoring-config/templates/00-cluster-monitoring-config.yaml
+++ b/infra/gp-cluster-monitoring-config/templates/00-cluster-monitoring-config.yaml
@@ -50,4 +50,6 @@ data:
     k8sPrometheusAdapter:
       {{- include "infranodes.enabled" . | nindent 6 }}
     thanosQuerier:
+      enableRequestLogging: "true"
+      logLevel: "info"
       {{- include "infranodes.enabled" . | nindent 6 }}


### PR DESCRIPTION
Wenn man in der console auf alerts drückt ist default, dass keine user alerts angezeigt werden.