### PR TITLE
GPX-177 - rook-ceph metriken sollen im platform prometheus landen

### DIFF
--- a/infra/gp-rook-ceph-operator/Chart.yaml
+++ b/infra/gp-rook-ceph-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: gp-rook-ceph-operator
 description: A Helm chart for Deploying the Rook-Ceph-Operator on OpenShift
 
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: v1.9.3
 
 dependencies:

--- a/infra/gp-rook-ceph-operator/templates/namespace.yaml
+++ b/infra/gp-rook-ceph-operator/templates/namespace.yaml
@@ -5,5 +5,6 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     kubernetes.io/metadata.name: rook-ceph
+    openshift.io/cluster-monitoring: "true"
   name: rook-ceph
 spec: {}


### PR DESCRIPTION
Wenn man in der console auf alerts drückt ist default, dass keine user alerts angezeigt werden.