### PR TITLE
GPX-177 - eventbus error monitoren

### DIFF
--- a/bke-development/gp-cicd-eventbus/Chart.yaml
+++ b/bke-development/gp-cicd-eventbus/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3

--- a/bke-development/gp-cicd-eventbus/templates/monitoring.yaml
+++ b/bke-development/gp-cicd-eventbus/templates/monitoring.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: eventbus
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+    - interval: 2m
+      port: metrics
+  selector:
+    matchLabels:
+      eventbus-name: default
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: eventsources
+  namespace: {{ .Release.Namespace }}
+spec:
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 2m
+  selector:
+    matchLabels:
+      controller: eventsource-controller
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: sensors
+  namespace: {{ .Release.Namespace }}
+spec:
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 2m
+  selector:
+    matchLabels:
+      controller: sensor-controller
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: argo-events-errors
+  namespace: {{ .Release.Namespace }}
+spec:
+  groups:
+    - name: argo-events-errors
+      rules:
+        - alert: ArgoEventsErrors #irgendein Name
+          expr: "rate(argo_events_events_processing_failed_total[4h])>0 or rate(argo_events_action_failed_total[4h])>0"
+          labels:
+            severity: warning
+          annotations:
+            description: {{ printf "Events konnten nicht verarbeitet werden. Prüfe Pod logs in {{$labels.namespace}}. Error Metric comes from Pod {{$labels.pod}}" }}
+            summary: "Argo Events hatte Fehler in den letzten 4 Stunden"
+---


### PR DESCRIPTION
Gelegentlich kommt es vor, dass githooks argo workflows nicht triggern.
Da kann es sein, dass der eventbus cluster einen schiefstand hat und ein pod gelöscht werden muss.
Damit wir das mitbekommen müssen zuerst die metriken gesammelt werden.
Eine Prometheus rule soll dann feuern wenn in den letzten 4 stunden ein error dazugekommen.