### PR TITLE
GPX-395 - alerting wenn thanos queries stecken

### DIFF
--- a/infra/gp-cluster-monitoring-config/Chart.yaml
+++ b/infra/gp-cluster-monitoring-config/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.6
+version: 1.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/gp-cluster-monitoring-config/templates/prometheusrule.yaml
+++ b/infra/gp-cluster-monitoring-config/templates/prometheusrule.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-engine-queries
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: prometheus_engine_queries
+      rules:
+        - alert: ThanosQueriesStuck
+          annotations:
+            description: |
+              Wenn 20 prometheus_engine_queries erreicht sind kommt es zu Gateway Timeouts in der Console bzw. bei Abfragen über den Thanos Querier Endpoint.
+              Derzeitige Lösung: Thanos Querier Pod löschen {{printf "{{$labels.pod}}"}}
+            summary: Thanos Querier erreicht bald 20 Prometheus Engine Queries
+          expr: sum by (pod) (prometheus_engine_queries{job="thanos-querier",container="kube-rbac-proxy-metrics"}) >= 10
+          for: 2m
+          labels:
+            severity: critical


### PR DESCRIPTION
Im container gibt es anscheinend 3 engines und die teilen sich die max concurrent von 20.