### PR TITLE
use default in Image for ArgoCD Instance

### DIFF
--- a/bke-development/gp-cicd-tools/values.yaml
+++ b/bke-development/gp-cicd-tools/values.yaml
@@ -167,7 +167,6 @@ argo_rollouts:
 ####################
 argocd:
   enabled: true
-  image: ghcr.io/gepaplexx/argocd
   route:
     hostname: "argocd.example.com"
   applicationset:
@@ -203,8 +202,6 @@ argocd:
         cpu: 250m
         memory: 128Mi
   repo:
-    image: ghcr.io/gepaplexx/argocd
-    version: main-87c3388
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
OpenShift GitOps ist mittlerweile in der Version 1.6. verfügbar. Diese kommt mit: 

- Helm 3.8.1
- Kustomize 4.4.1
- ArgoCD 2.4.5

und liefert zum einen: Notifications Controller (sollten wir uns ansehen) und die Möglichkeit Custom ArgoCD Plugins zu verwenden. Ein eigenes ArgoCD Image sollten wir dementsprechend nicht mehr benötigen. 

Zur Verwendung von eigenen Plugins und der Erweiterung von ArgoCD um diese:
https://argo-cd.readthedocs.io/en/stable/user-guide/config-management-plugins/
https://argo-cd.readthedocs.io/en/stable/operator-manual/custom_tools/

Build-Your-Own-Image wird zwar auch von ArgoCD auf deren Dokumentation beschrieben. Für neuere Version wird jedoch der Weg über init-Container und VolumeMounts präferiert. 
Solange wir keinen Bedarf an einem Custom-Image haben, sollten wir beim Standard bleiben. 