### PR TITLE
GPX-415: Autorisierung ArgoCD

### DIFF
--- a/bke-development/gp-cicd-tools/Chart.yaml
+++ b/bke-development/gp-cicd-tools/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.5.0
 
 dependencies:
 - name: argo-events

--- a/bke-development/gp-cicd-tools/templates/01-argocd-instance.yaml
+++ b/bke-development/gp-cicd-tools/templates/01-argocd-instance.yaml
@@ -42,7 +42,11 @@ spec:
   prometheus:
     enabled: false
   rbac:
-    policy: g, Gepaplexx, role:admin
+    defaultPolicy: '{{ .Values.argocd.rbac.defaultPolicy }}'
+    policy: |
+      {{- range .Values.argocd.rbac.policies }}
+      {{ . }}
+      {{- end }}
     scopes: '[groups]'
   redis:
     resources:

--- a/bke-development/gp-cicd-tools/values.yaml
+++ b/bke-development/gp-cicd-tools/values.yaml
@@ -217,6 +217,14 @@ argocd:
       requests:
         cpu: 250m
         memory: 128Mi
+  rbac:
+    defaultPolicy: ''
+    policies:
+      - 'p, role:gepardec-admin, applications, *, *, allow'
+      - 'p, role:gepardec-admin, repositories, *, *, allow'
+      - 'p, role:gepardec-admin, projects, *, *, allow'
+      - 'g, Gepaplexx, role:admin'
+      - 'g, Gepardec, role:gepardec-admin'
 
 ######################
 ##    Postgresql    ##

--- a/infra/gp-cluster-config/Chart.yaml
+++ b/infra/gp-cluster-config/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.2
+version: 1.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/gp-cluster-config/templates/10-argocd-rbac-patch.yaml
+++ b/infra/gp-cluster-config/templates/10-argocd-rbac-patch.yaml
@@ -15,5 +15,9 @@ spec:
       patchTemplate: |
         spec:
           rbac:
-            policy: 'g, Gepaplexx, role:admin'
+            defaultPolicy: '{{ .Values.argocd.rbac.defaultPolicy }}'
+            policy: |
+              {{- range .Values.argocd.rbac.policies }}
+              {{ . }}
+              {{- end }}
       patchType: application/merge-patch+json

--- a/infra/gp-cluster-config/values.yaml
+++ b/infra/gp-cluster-config/values.yaml
@@ -34,6 +34,10 @@ argocd:
     sshPrivateKey: "" # must be supplied via value in argocd application
     secretName: "workflow-repository"
     url: "git@github.com:gepaplexx/gepaplexx-cicd.git"
+  rbac:
+    defaultPolicy: ''
+    policies:
+      - 'g, Gepaplexx, role:admin'
 
 patchOperator:
   namespace: gp-infrastructure


### PR DESCRIPTION
Initiale Berechtigungen für Gepardec und Gepaplexx gesetzt.
openshift-gitops ArgoCD: nur Gepaplexx hat admin Rechte, alle anderen User können sich einloggen, sehen aber nichts.
gepaplexx-cicd-tools ArgoCD: Gepaplexx ist admin, Gepardec darf Applications, Repositories und Projekte ändern.