### PR TITLE
Feature/gpx 466

### DIFF
--- a/infra/gp-keycloak-instance/.helmignore
+++ b/infra/gp-keycloak-instance/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infra/gp-keycloak-instance/Chart.yaml
+++ b/infra/gp-keycloak-instance/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: gp-keycloak-instance
+description: A Helm chart for deploying Keycloak on OpenShift using the Keycloak-X Operator
+
+type: application
+version: 0.1.0
+
+dependencies:
+  - name: postgresql
+    repository: "https://charts.bitnami.com/bitnami"
+    version: ~11.6.14
+    condition: persistence.enabled

--- a/infra/gp-keycloak-instance/templates/_helpers.tpl
+++ b/infra/gp-keycloak-instance/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gp-keycloak-instance.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gp-keycloak-instance.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gp-keycloak-instance.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gp-keycloak-instance.labels" -}}
+helm.sh/chart: {{ include "gp-keycloak-instance.chart" . }}
+{{ include "gp-keycloak-instance.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gp-keycloak-instance.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gp-keycloak-instance.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gp-keycloak-instance.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gp-keycloak-instance.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/infra/gp-keycloak-instance/templates/config-secret.yaml
+++ b/infra/gp-keycloak-instance/templates/config-secret.yaml
@@ -1,0 +1,50 @@
+{{- if or .Values.persistence.enabled .Values.provider.openshift.enabled }}
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: keycloak-config
+  namespace: gp-sso
+spec:
+  encryptedData:
+    clientSecret: {{ .Values.provider.openshift.clientSecret }}
+    {{- if .Values.persistence.enabled }}
+    password: {{ .Values.persistence.auth.password }}
+    postgres-password: {{ .Values.persistence.auth.password }}
+    {{- end }}
+  template:
+    data:
+      username: {{ .Values.postgresql.auth.username }}
+    metadata:
+      creationTimestamp: null
+      labels:
+      {{- include "gp-keycloak-instance.labels" . | nindent 8 }}
+      name: keycloak-config
+      namespace: gp-sso
+    type: Opaque
+---
+{{- if .Values.provider.openshift.enabled }}
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Patch
+metadata:
+  name: patch-keycloak-oauthclient
+  namespace: {{ .Values.patch.namespace }}
+spec:
+  serviceAccountRef:
+    name: {{ .Values.patch.serviceAccount }}
+  patches:
+    patch-oauthclient:
+      targetObjectRef:
+        apiVersion: oauth.openshift.io/v1
+        kind: OAuthClient
+        name: keycloak
+      patchTemplate: |
+        secret: {{`{{ (index . 1).data.clientSecret | b64dec }}`}}
+      patchType: application/merge-patch+json
+      sourceObjectRefs:
+        - apiVersion: v1
+          kind: Secret
+          name: keycloak-config
+          namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/infra/gp-keycloak-instance/templates/keycloak.yaml
+++ b/infra/gp-keycloak-instance/templates/keycloak.yaml
@@ -1,0 +1,34 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: sso
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gp-keycloak-instance.labels" . | nindent 4 }}
+spec:
+  hostname: {{  .Values.ingress.hostname }}
+  instances: {{ .Values.replicas }}
+  serverConfiguration:
+    - name: features-disabled
+      value: "{{ .Values.features.disabled }}"
+    - name: features
+      value: "{{ .Values.features.enabled }}"
+    - name: health_enabled
+      value: 'true'
+    - name: metrics-enabled
+      value: 'true'
+  {{- if .Values.persistence.enabled }}
+    - name: db
+      value: postgres
+    - name: db-url-host
+      value: {{ .Values.postgresql.fullnameOverride }}
+    - name: db-username
+      secret:
+        name:  keycloak-config
+        key: username
+    - name: db-password
+      secret:
+        name: keycloak-config
+        key: password
+  {{- end }}
+  tlsSecret: keycloak-tls

--- a/infra/gp-keycloak-instance/templates/keycloak.yaml
+++ b/infra/gp-keycloak-instance/templates/keycloak.yaml
@@ -13,7 +13,7 @@ spec:
       value: "{{ .Values.features.disabled }}"
     - name: features
       value: "{{ .Values.features.enabled }}"
-    - name: health_enabled
+    - name: health-enabled
       value: 'true'
     - name: metrics-enabled
       value: 'true'

--- a/infra/gp-keycloak-instance/templates/oauth-client.yaml
+++ b/infra/gp-keycloak-instance/templates/oauth-client.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.provider.openshift.enabled }}
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+grantMethod: prompt
+metadata:
+  name: keycloak
+  labels:
+    {{- include "gp-keycloak-instance.labels" . | nindent 4 }}
+redirectURIs:
+  - https://{{ .Values.ingress.hostname }}/realms/{{ .Values.realm.internalName }}/
+secret: "will-be-patched"
+{{- end }}

--- a/infra/gp-keycloak-instance/templates/tls-certificate.yaml
+++ b/infra/gp-keycloak-instance/templates/tls-certificate.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keycloak-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gp-keycloak-instance.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - {{ .Values.ingress.hostname }}
+  duration: 2160h0m0s
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  renewBefore: 360h0m0s
+  secretName: keycloak-tls
+  usages:
+    - server auth
+    - client auth

--- a/infra/gp-keycloak-instance/values.yaml
+++ b/infra/gp-keycloak-instance/values.yaml
@@ -1,0 +1,44 @@
+patch:
+  namespace: gp-infrastructure
+  serviceAccount: patch-operator-sa
+ingress:
+  hostname: sso.apps.cluster.example.com
+realm:
+  internalName: internal
+
+replicas: 1
+persistence:
+  enabled: true
+  auth:
+    password: ""
+features:
+  # Comma separeted list of features to be disabled
+  disabled: "admin2"
+  # Comma separeted list of features to be enabled
+  enabled: "openshift-integration"
+
+provider:
+  openshift:
+    enabled: true
+    clientSecret: ""
+
+######################
+##    Postgresql    ##
+######################
+postgresql:
+  fullnameOverride: postgresql-keycloak
+  service:
+    ports:
+      postgresql: 5432
+  auth:
+    username: keycloak # don't override
+    database: keycloak # don't override
+    existingSecret: keycloak-config # don't override
+  primary:
+    podSecurityContext:
+      enabled: false
+    containerSecurityContext:
+      enabled: false
+    persistence:
+      size: 8Gi
+

--- a/infra/gp-keycloak-operator/.helmignore
+++ b/infra/gp-keycloak-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infra/gp-keycloak-operator/Chart.yaml
+++ b/infra/gp-keycloak-operator/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: gp-keycloak-operator
+description: A Helm chart for deploying the keycloak-x operator on OpenShift
+type: application
+
+
+version: 0.1.0

--- a/infra/gp-keycloak-operator/templates/_helpers.tpl
+++ b/infra/gp-keycloak-operator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gp-keycloak-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gp-keycloak-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gp-keycloak-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gp-keycloak-operator.labels" -}}
+helm.sh/chart: {{ include "gp-keycloak-operator.chart" . }}
+{{ include "gp-keycloak-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gp-keycloak-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gp-keycloak-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gp-keycloak-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gp-keycloak-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/infra/gp-keycloak-operator/templates/subscription.yaml
+++ b/infra/gp-keycloak-operator/templates/subscription.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+
+kind: Subscription
+metadata:
+  labels:
+    {{ include "gp-keycloak-operator.labels" . | nindent 4 }}
+  name: keycloak-operator
+  namespace: {{ .Release.Namespace }}
+spec:
+  channel: {{ .Values.update.channel }}
+  installPlanApproval: {{ .Values.update.approval }}
+  name: keycloak-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/infra/gp-keycloak-operator/templates/subscription.yaml
+++ b/infra/gp-keycloak-operator/templates/subscription.yaml
@@ -1,9 +1,17 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{ .Release.Namespace }}-og
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetNamespaces:
+    - {{ .Release.Namespace }}
+---
 apiVersion: operators.coreos.com/v1alpha1
-
 kind: Subscription
 metadata:
   labels:
-    {{ include "gp-keycloak-operator.labels" . | nindent 4 }}
+    {{- include "gp-keycloak-operator.labels" . | nindent 4 }}
   name: keycloak-operator
   namespace: {{ .Release.Namespace }}
 spec:

--- a/infra/gp-keycloak-operator/values.yaml
+++ b/infra/gp-keycloak-operator/values.yaml
@@ -1,0 +1,3 @@
+update:
+  channel: candidate
+  approval: Automatic


### PR DESCRIPTION
Helm Charts für die Keycloak Installation auf Gepaplexx-Clustern hinzugefügt. 

- gp-keycloak-operator:  deployed den keycloak operator in den "gp-sso" Namespace. 
- gp-keycloak-instance: deployed eine keycloak instanz in den "gp-sso" Namespace und legt einen OauthClient in OpenShift an, damit OpenShift als IdentityProvider in Keycloak integriert werden kann. Anleitung zum Erzeugen von Realms und IdentityProvider Einbindung ist zu finden unter: https://gepardec.atlassian.net/wiki/spaces/G/pages/2490466305/Keycloak

Hängt zusammen mit folgenden PRs: 

- https://github.com/gepaplexx/gepardec-run-cluster-configuration/pull/20
- https://github.com/gepaplexx/application-day-x-generator/pull/14
