### PR TITLE
GPX-296 [CICD] Permissions & Security Argo Workflows/CD

### DIFF
--- a/bke-development/gp-cicd-tools/.helmignore
+++ b/bke-development/gp-cicd-tools/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+rbac_templates/

--- a/bke-development/gp-cicd-tools/Chart.yaml
+++ b/bke-development/gp-cicd-tools/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.14
+version: 0.6.15
 
 dependencies:
 - name: argo-events

--- a/bke-development/gp-cicd-tools/rbac_templates/rbac.yaml
+++ b/bke-development/gp-cicd-tools/rbac_templates/rbac.yaml
@@ -1,0 +1,48 @@
+## Examples for Namespace permissions:
+apiVersion: v1
+kind: Secret
+metadata:
+  name: workflow-developer-token
+  namespace: $NAMESPACE
+  annotations:
+    kubernetes.io/service-account.name: workflow-developer
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workflow-developer
+  namespace: $NAMESPACE
+  annotations:
+    workflows.argoproj.io/rbac-rule: "'$GROUPNAME' in groups"
+    workflows.argoproj.io/rbac-rule-precedence: "300"
+secrets:
+  - name: workflow-developer-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workflow-developer-binding
+  namespace: $NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: workflow-developer-role
+subjects:
+  - kind: ServiceAccount
+    name: workflow-developer
+    namespace: $NAMESPACE
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: $NAMESPACE-cicd-clusterworkflow-binding
+  namespace: $NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: workflow-clusterresources-role
+subjects:
+  - kind: ServiceAccount
+    name: workflow-developer
+    namespace: $NAMESPACE

--- a/bke-development/gp-cicd-tools/templates/02-rbac.yaml
+++ b/bke-development/gp-cicd-tools/templates/02-rbac.yaml
@@ -28,6 +28,14 @@ rules:
       - workflowtasksets
       - workflowtemplates
       - workflowtaskresults
+  - apiGroups:
+      - ""
+    verbs:
+      - get
+    resources:
+      - secrets
+    resourceNames:
+      - minio-artifact-repository
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/bke-development/gp-cicd-tools/templates/workflows-sso-config.yaml
+++ b/bke-development/gp-cicd-tools/templates/workflows-sso-config.yaml
@@ -1,7 +1,6 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  creationTimestamp: null
   name: {{ .Values.argo_workflows.server.sso.clientSecret.name }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -16,6 +15,15 @@ spec:
 ## BEGINN DEFAULT READONLY USER
 # Default ReadOnly SA for OAuth authenticated users
 apiVersion: v1
+kind: Secret
+metadata:
+  name: workflows-read-only-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: workflows-read-only
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: workflows-read-only
@@ -23,6 +31,8 @@ metadata:
   annotations:
     workflows.argoproj.io/rbac-rule: "'system:authenticated:oauth' in groups"
     workflows.argoproj.io/rbac-rule-precedence: "0"
+secrets:
+  - name: workflows-read-only-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -62,7 +72,17 @@ rules:
     - pods/log
     - pods/status
     - pods
+# erlaubt das Abrufen von Logs von Archived Workflows.
+- apiGroups:
+    - ""
+  verbs:
+    - get
+  resources:
+    - secrets
+  resourceNames:
+    - minio-artifact-repository
 ---
+{{- if .Values.argo_workflows.rbac.defaultRead }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -78,7 +98,17 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ## END DEFAULT READONLY USER
 ---
+{{- end }}
 ## BEGIN GEPAPLEXX ARGO WORKFLOWS SUPER USER
+apiVersion: v1
+kind: Secret
+metadata:
+  name: workflows-super-admin-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: workflows-super-admin
+type: kubernetes.io/service-account-token
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -87,6 +117,8 @@ metadata:
   annotations:
     workflows.argoproj.io/rbac-rule: "'{{ .Values.argo_workflows.rbac.sudoGroup }}' in groups"
     workflows.argoproj.io/rbac-rule-precedence: "999"
+secrets:
+  - name: workflows-super-admin-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -96,19 +128,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: operate-workflow-role
-subjects:
-  - kind: ServiceAccount
-    name: workflows-super-admin
-    namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: workflows-super-admin-admin-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
 subjects:
   - kind: ServiceAccount
     name: workflows-super-admin
@@ -158,17 +177,37 @@ rules:
       - pods/log
       - pods/status
       - pods
+  # erlaubt das Abrufen von Logs von Archived Workflows.
+  - apiGroups:
+      - ""
+    verbs:
+      - get
+    resources:
+      - secrets
+    resourceNames:
+      - minio-artifact-repository
 ---
 {{- if .Values.argo_workflows.rbac.clusterscoped.enabled }}
 # ServiceAccount und Clusterrolebinding nur anlegen, wenn es eine Gruppe gibt, die Clusterweit Workflows anlegen darf
 apiVersion: v1
+kind: Secret
+metadata:
+  name: workflow-developer-default-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: workflow-developer-default
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: workflow-developer
+  name: workflow-developer-default
   namespace: {{ .Release.Namespace }}
   annotations:
     workflows.argoproj.io/rbac-rule: "'{{ .Values.argo_workflows.rbac.clusterscoped.developerGroup }}' in groups"
     workflows.argoproj.io/rbac-rule-precedence: "100"
+secrets:
+  - name: workflow-developer-default-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -180,10 +219,24 @@ roleRef:
   name: workflow-developer-role
 subjects:
   - kind: ServiceAccount
-    name: workflow-developer
+    name: workflow-developer-default
     namespace: {{ .Release.Namespace }}
 ## END ARGO WORKFLOWS DEVELOPER PERMISSIONS
 ---
 {{- end }}
-
-
+# Required for Namespace Delegation so Clusterworkflowtemplates can be used during workflow execution
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workflow-clusterresources-role
+rules:
+  - apiGroups:
+      - argoproj.io
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+    resources:
+      - clusteranalysistemplates
+      - clusterworkflowtemplates
+---

--- a/bke-development/gp-cicd-tools/values.yaml
+++ b/bke-development/gp-cicd-tools/values.yaml
@@ -68,6 +68,7 @@ argo_workflows:
     clusterscoped:
       developerGroup: Gepardec
       enabled: false
+    defaultRead: true
 
   enabled: true
   fullnameOverride: argo-workflows


### PR DESCRIPTION
Änderungen bei ServiceAccounts und deren Secrets für API-Token. Fix Permissions:
* Read-Only User darf logs sehen (wenn konfiguriert)
* Permissions auf Namespaces sollten durch Änderungen nun auch funktionieren. Template für RBAC in Namespaces hinzugefügt.

Signed-off-by: fhochleitner <felix.hochleitner@outlook.com>