### PR TITLE
Certificate defines service address as well because scraped by servic…

### DIFF
--- a/infra/gp-keycloak-instance/templates/servicemonitor.yaml
+++ b/infra/gp-keycloak-instance/templates/servicemonitor.yaml
@@ -7,6 +7,13 @@ spec:
     - interval: 5s
       port: metrics
       scheme: https
+      tlsConfig:
+        ca:
+          secret:
+            name: '{{ include "gp-keycloak-instance.fullname" . }}-tls'
+            key: tls.crt
+            optional: false
+        serverName: '{{ include "gp-keycloak-instance.fullname" . }}-service-metrics.{{ .Release.Namespace }}.svc'
   selector:
     matchLabels:
       metrics-service: sso

--- a/infra/gp-keycloak-instance/templates/tls-certificate.yaml
+++ b/infra/gp-keycloak-instance/templates/tls-certificate.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   dnsNames:
     - {{ .Values.ingress.hostname }}
+    - '{{ include "gp-keycloak-instance.fullname" . }}-service-metrics.{{ .Release.Namespace }}.svc' # fro scraping https
   duration: 2160h0m0s
   issuerRef:
     kind: ClusterIssuer


### PR DESCRIPTION
…emonitor. servicemonitor defines servername which is service-metrics address