### PR TITLE
tls cert second entry removed, not valid dns name with *.svc. service…

### DIFF
--- a/infra/gp-keycloak-instance/templates/servicemonitor.yaml
+++ b/infra/gp-keycloak-instance/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
             name: '{{ include "gp-keycloak-instance.fullname" . }}-tls'
             key: tls.crt
             optional: false
-        serverName: '{{ include "gp-keycloak-instance.fullname" . }}-service-metrics.{{ .Release.Namespace }}.svc'
+        serverName: '{{ .Values.ingress.hostname }}'
   selector:
     matchLabels:
       metrics-service: sso

--- a/infra/gp-keycloak-instance/templates/tls-certificate.yaml
+++ b/infra/gp-keycloak-instance/templates/tls-certificate.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   dnsNames:
     - {{ .Values.ingress.hostname }}
-    - '{{ include "gp-keycloak-instance.fullname" . }}-service-metrics.{{ .Release.Namespace }}.svc' # fro scraping https
   duration: 2160h0m0s
   issuerRef:
     kind: ClusterIssuer


### PR DESCRIPTION
…monitor servername is ingress.hostname, still communicates via IP