### PR TITLE
Loki Permissions base

### DIFF
--- a/infra/gp-grafana-instance/Chart.yaml
+++ b/infra/gp-grafana-instance/Chart.yaml
@@ -3,4 +3,4 @@ name: gp-grafana-instance
 description: A Helm chart for deploying Grafana on OpenShift
 
 type: application
-version: 0.2.4
+version: 0.2.5

--- a/infra/gp-grafana-instance/templates/01-grafana-crd.yaml
+++ b/infra/gp-grafana-instance/templates/01-grafana-crd.yaml
@@ -54,4 +54,4 @@ spec:
             key: service-ca.crt
             name: openshift-service-ca.crt
       - name: GATEWAY_ADDRESS
-        value: 'logging-loki-query-frontend-http.openshift-logging.svc:3100'
+        value: 'logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/'

--- a/infra/gp-grafana-instance/templates/02-system-datasources.yaml
+++ b/infra/gp-grafana-instance/templates/02-system-datasources.yaml
@@ -14,51 +14,50 @@ spec:
       jsonData:
         httpMethod: POST
         httpHeaderName1: Authorization # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
+        oauthPassThru: false #TODO auf true setzen, nach GPX-495
       secureJsonData:
         httpHeaderValue1: 'Bearer need-to-set-token-manually' # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
     - name: Loki (Application)
       type: loki
-      url: https://${GATEWAY_ADDRESS}/
+      url: https://${GATEWAY_ADDRESS}/application/
       access: proxy
       editable: true
       isDefault: false
       jsonData:
         httpMethod: POST
         httpHeaderName1: Authorization # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        httpHeaderName2: X-Scope-OrgID
+        oauthPassThru: false #TODO auf true setzen, nach GPX-495
         tlsAuthWithCACert: true
       secureJsonData:
         httpHeaderValue1: 'Bearer need-to-set-token-manually' # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        httpHeaderValue2: application
         tlsCACert: ${GATEWAY_SERVICE_CA}
     - name: Loki (Infrastructure)
       type: loki
-      url: https://${GATEWAY_ADDRESS}/
+      url: https://${GATEWAY_ADDRESS}/infrastructure/
       access: proxy
       editable: true
       isDefault: false
       jsonData:
         httpMethod: POST
         httpHeaderName1: Authorization # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        httpHeaderName2: X-Scope-OrgID
+        oauthPassThru: false #TODO auf true setzen, nach GPX-495
         tlsAuthWithCACert: true
       secureJsonData:
         httpHeaderValue1: 'Bearer need-to-set-token-manually' # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        httpHeaderValue2: infrastructure
         tlsCACert: ${GATEWAY_SERVICE_CA}
     - name: Loki (Audit)
       type: loki
-      url: https://${GATEWAY_ADDRESS}/
+      url: https://${GATEWAY_ADDRESS}/audit/
       access: proxy
       editable: true
       isDefault: false
       jsonData:
         httpMethod: POST
         httpHeaderName1: Authorization # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
+        oauthPassThru: false #TODO auf true setzen, nach GPX-495
         httpHeaderName2: X-Scope-OrgID
         tlsAuthWithCACert: true
       secureJsonData:
         httpHeaderValue1: 'Bearer need-to-set-token-manually' # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        httpHeaderValue2: audit
         tlsCACert: ${GATEWAY_SERVICE_CA}
   name: system-datasources.yaml


### PR DESCRIPTION
Verwendung des Loki HTTP Gateways anstatt des querier-frontends direkt. Das http-gateway benötigt einen gültigen OpenShift Bearer Token, damit es Daten zurückliefert. Damit haben wir für Loki jetzt denselben Stand wie bei Prometheus und müssen nur noch den richtigen Token in Grafana haben und weiterleiten.

Signed-off-by: fhochleitner <felix.hochleitner@outlook.com>