### PR TITLE
GPX-519 Keine Nachrichten zu Updates, wenn Cluster nicht upge…

### DIFF
--- a/infra/gp-cluster-update-checker/Chart.yaml
+++ b/infra/gp-cluster-update-checker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2
+version: 1.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/gp-cluster-update-checker/templates/04-cluster-update-checker-job.yaml
+++ b/infra/gp-cluster-update-checker/templates/04-cluster-update-checker-job.yaml
@@ -37,8 +37,8 @@ spec:
             command: ["/bin/bash", "-c"]
             args:
               - |
-                currentChannel=$(oc get clusterversion -o jsonpath="{.items[0].spec.channel}") 
-                newestChannel=$(oc get clusterversion -o=jsonpath="{.items[0].status.desired.channels}" | jq '.[] | select(test("stable"))' | sort -Vr | head -1 | cut -d '"' -f 2)
+                currentChannel=$(oc get clusterversion version -o jsonpath="{.spec.channel}")
+                newestChannel=$(oc get clusterversion version -o=jsonpath="{.status.desired.channels}" | jq '.[] | select(test("{{ .Values.checker.desiredChannel }}"))' | sort -Vr | head -1 | cut -d '"' -f 2)
 
                 echo "Current Channel is $currentChannel"
                 echo "Newest Channel is  $newestChannel"
@@ -51,8 +51,8 @@ spec:
                               
                 CURRENT_VERSION=$(oc adm upgrade | sed -n -e 's/Cluster version is //p');
                 echo "AKTUELLE VERSION ist $CURRENT_VERSION";
-                UPDATES=$(oc get clusterversion -o jsonpath='{.items[].status.availableUpdates}{"\n"}');
-                VERSIONS=$(oc get clusterversion -o jsonpath='{.items[].status.availableUpdates[*].version}{"\n"}');
+                UPDATES=$(oc get clusterversion version -o jsonpath='{.status.availableUpdates}{"\n"}');
+                VERSIONS=$(oc get clusterversion version -o jsonpath='{.status.availableUpdates[*].version}{"\n"}');
                 echo "VERFUEGBARE VERSIONEN sind $VERSIONS";
                 NEW_VERSION=$(echo $VERSIONS | tr " " "\n" | sort -Vr | head -1);
                 echo "AUSGEWAEHLTE VERSION ist $NEW_VERSION";

--- a/infra/gp-cluster-update-checker/values.yaml
+++ b/infra/gp-cluster-update-checker/values.yaml
@@ -13,6 +13,7 @@ checker:
     requests:
       memory: "100Mi"
       cpu: "10m"
+  desiredChannel: "stable"
 
 updater:
   schedule: '"0 3 * * 2-5"'


### PR DESCRIPTION
…dated werden kann.

Part 1: Einstellung des Update-Channels, damit wir auf dem Play Cluster früher die Updates erhalten als auf dem Steppe Cluster

Signed-off-by: fhochleitner <felix.hochleitner@outlook.com>