### PR TITLE
Anpassungen Lokistack - Ruler und Logretention

### DIFF
--- a/infra/gp-cluster-logging-instance/Chart.yaml
+++ b/infra/gp-cluster-logging-instance/Chart.yaml
@@ -3,7 +3,7 @@ name: gp-cluster-logging-instance
 description: A Helm chart for Kubernetes
 
 type: application
-version: 2.0.6
+version: 2.0.7
 
 dependencies:
   - name: minio

--- a/infra/gp-cluster-logging-instance/templates/lokistack.yaml
+++ b/infra/gp-cluster-logging-instance/templates/lokistack.yaml
@@ -25,10 +25,6 @@ spec:
             - 'true'
   limits:
     global:
-      # in der aktuellen Version des Loki-Operators in OpenShift noch nicht unterstützt.
-      # lt. Dokuemntation sollte das allerdings so funktionieren: https://loki-operator.dev/docs/retention_support.md/#implementation-detailsnotesconstraints
-#      retentionLimits:
-#        periodDays: {{ .Values.lokistack.configuration.limits.logRetention }}
       ingestion:
         ingestionRate: {{ .Values.lokistack.configuration.limits.ingestion.ingestionRate }}
         ingestionBurstSize: {{ .Values.lokistack.configuration.limits.ingestion.ingestionBurstSize }}

--- a/infra/gp-cluster-logging-instance/templates/lokistack.yaml
+++ b/infra/gp-cluster-logging-instance/templates/lokistack.yaml
@@ -4,10 +4,31 @@ metadata:
   name: logging-loki
   namespace: openshift-logging
   labels:
-  {{- include "gp-clusterlogging-instance.labels" . | nindent 4}}
+  {{- include "gp-clusterlogging-instance.labels" . | nindent 4 }}
 spec:
+  rules:
+    enabled: {{ .Values.lokistack.rules.enabled }}
+    # Standardmäßig werden alle Namespaces für die Rule discovery herangezogen. Außer es wird das Label "logging.alerts.disabled" auf den Namespace gesetzt.
+    namespaceSelector:
+      matchExpressions:
+        - key: logging.alerts.disabled
+          operator: NotIn
+          values:
+            - 'true'
+    # Standardmäßig werden alle Rules in Namespaces herangezogen und die darin enthaltenen Alerting-/Recordingrules als aktiv betrachtet.
+    # Ausnahme: das label "logging.rule.disabled" wird auf die jeweilige Rule gesetzt.
+    selector:
+      matchExpressions:
+        - key: logging.rule.disabled
+          operator: NotIn
+          values:
+            - 'true'
   limits:
     global:
+      # in der aktuellen Version des Loki-Operators in OpenShift noch nicht unterstützt.
+      # lt. Dokuemntation sollte das allerdings so funktionieren: https://loki-operator.dev/docs/retention_support.md/#implementation-detailsnotesconstraints
+#      retentionLimits:
+#        periodDays: {{ .Values.lokistack.configuration.limits.logRetention }}
       ingestion:
         ingestionRate: {{ .Values.lokistack.configuration.limits.ingestion.ingestionRate }}
         ingestionBurstSize: {{ .Values.lokistack.configuration.limits.ingestion.ingestionBurstSize }}

--- a/infra/gp-cluster-logging-instance/values.yaml
+++ b/infra/gp-cluster-logging-instance/values.yaml
@@ -19,7 +19,6 @@ lokistack:
       queries:
         maxChunksPerQuery: 4000000
         maxQueriesSeries: 1000
-      logRetention: 31
     size: 1x.small  # Valid values are: 1x.extra-small, 1x.small, 1x.medium
     compactor:
       replicas: 1

--- a/infra/gp-cluster-logging-instance/values.yaml
+++ b/infra/gp-cluster-logging-instance/values.yaml
@@ -3,6 +3,9 @@ infranodes:
 clusterlogging:
   managementState: "Managed"
 lokistack:
+  # Aktiviert die Ruler Komponente um aufgrund von Logfiles Alerts abschicken zu können.
+  rules:
+    enabled: true
   minio:
     enabled: false
   configuration:
@@ -16,6 +19,7 @@ lokistack:
       queries:
         maxChunksPerQuery: 4000000
         maxQueriesSeries: 1000
+      logRetention: 31
     size: 1x.small  # Valid values are: 1x.extra-small, 1x.small, 1x.medium
     compactor:
       replicas: 1


### PR DESCRIPTION
Anpassungen Lokistack für: 

- Ruler grundsätzlich aktiviert. 
-  Opt-Out für Rule-Discovery hinzugefügt. 