### PR TITLE
GPX-468 - aufräumen von grafana konfiguration

### DIFF
--- a/infra/gp-grafana-instance/Chart.yaml
+++ b/infra/gp-grafana-instance/Chart.yaml
@@ -3,4 +3,4 @@ name: gp-grafana-instance
 description: A Helm chart for deploying Grafana on OpenShift
 
 type: application
-version: 0.2.5
+version: 0.2.6

--- a/infra/gp-grafana-instance/templates/01-grafana-crd.yaml
+++ b/infra/gp-grafana-instance/templates/01-grafana-crd.yaml
@@ -48,10 +48,17 @@ spec:
             - application
   deployment:
     env:
-      - name: GATEWAY_SERVICE_CA
+      - name: SERVICE_CA
         valueFrom:
           configMapKeyRef:
             key: service-ca.crt
             name: openshift-service-ca.crt
-      - name: GATEWAY_ADDRESS
-        value: 'logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/'
+      - name: LOKI_GATEWAY_ADDRESS
+        value: 'https://logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/'
+      - name: THANOS_QUERIER_ADDRESS
+        value: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
+      - name: BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            key: token
+            name: grafana-serviceaccount-token

--- a/infra/gp-grafana-instance/templates/02-system-datasources.yaml
+++ b/infra/gp-grafana-instance/templates/02-system-datasources.yaml
@@ -7,57 +7,58 @@ spec:
   datasources:
     - name: Prometheus
       type: prometheus
-      url: {{ .Values.datasource.prometheus.url }}
+      url: ${THANOS_QUERIER_ADDRESS}
       access: proxy
       editable: true
       isDefault: true
       jsonData:
         httpMethod: POST
-        httpHeaderName1: Authorization # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        oauthPassThru: false #TODO auf true setzen, nach GPX-495
+        httpHeaderName1: Authorization
+        oauthPassThru: false
+        tlsAuthWithCACert: true
       secureJsonData:
-        httpHeaderValue1: 'Bearer need-to-set-token-manually' # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
+        httpHeaderValue1: Bearer ${BEARER_TOKEN}
+        tlsCACert: ${SERVICE_CA}
     - name: Loki (Application)
       type: loki
-      url: https://${GATEWAY_ADDRESS}/application/
+      url: ${LOKI_GATEWAY_ADDRESS}/application/
       access: proxy
       editable: true
       isDefault: false
       jsonData:
         httpMethod: POST
-        httpHeaderName1: Authorization # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        oauthPassThru: false #TODO auf true setzen, nach GPX-495
+        httpHeaderName1: Authorization
+        oauthPassThru: false
         tlsAuthWithCACert: true
       secureJsonData:
-        httpHeaderValue1: 'Bearer need-to-set-token-manually' # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        tlsCACert: ${GATEWAY_SERVICE_CA}
+        httpHeaderValue1: Bearer ${BEARER_TOKEN}
+        tlsCACert: ${SERVICE_CA}
     - name: Loki (Infrastructure)
       type: loki
-      url: https://${GATEWAY_ADDRESS}/infrastructure/
+      url: ${LOKI_GATEWAY_ADDRESS}/infrastructure/
       access: proxy
       editable: true
       isDefault: false
       jsonData:
         httpMethod: POST
-        httpHeaderName1: Authorization # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        oauthPassThru: false #TODO auf true setzen, nach GPX-495
+        httpHeaderName1: Authorization
+        oauthPassThru: false
         tlsAuthWithCACert: true
       secureJsonData:
-        httpHeaderValue1: 'Bearer need-to-set-token-manually' # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        tlsCACert: ${GATEWAY_SERVICE_CA}
+        httpHeaderValue1: Bearer ${BEARER_TOKEN}
+        tlsCACert: ${SERVICE_CA}
     - name: Loki (Audit)
       type: loki
-      url: https://${GATEWAY_ADDRESS}/audit/
+      url: ${LOKI_GATEWAY_ADDRESS}/audit/
       access: proxy
       editable: true
       isDefault: false
       jsonData:
         httpMethod: POST
-        httpHeaderName1: Authorization # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        oauthPassThru: false #TODO auf true setzen, nach GPX-495
-        httpHeaderName2: X-Scope-OrgID
+        httpHeaderName1: Authorization
+        oauthPassThru: false
         tlsAuthWithCACert: true
       secureJsonData:
-        httpHeaderValue1: 'Bearer need-to-set-token-manually' # TODO remove after GPX-495 Grafana Datasource Integration - Forward OAuth Identity
-        tlsCACert: ${GATEWAY_SERVICE_CA}
+        httpHeaderValue1: Bearer ${BEARER_TOKEN}
+        tlsCACert: ${SERVICE_CA}
   name: system-datasources.yaml

--- a/infra/gp-grafana-instance/templates/05-rbac.yaml
+++ b/infra/gp-grafana-instance/templates/05-rbac.yaml
@@ -12,3 +12,26 @@ roleRef:
   name: cluster-monitoring-view
   apiGroup: rbac.authorization.k8s.io
 ---
+## Grafana temporarily gets cluster-admin rights to query loki logs
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-cluster-admin-binding
+subjects:
+  - kind: ServiceAccount
+    name: grafana-serviceaccount
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+---
+# static secret to have a token with cluster admin rights
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-serviceaccount-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: grafana-serviceaccount
+type: kubernetes.io/service-account-token

--- a/infra/gp-grafana-instance/values.yaml
+++ b/infra/gp-grafana-instance/values.yaml
@@ -13,12 +13,6 @@ sso:
     clientSecret: ""
     clientId: "grafana"
     realmUrl: "https://sso.apps.clustername.basedomain.com/realms/realmname"
-datasource:
-  prometheus:
-    url: "https://thanos-querier-openshift-monitoring.apps.example.gepaplexx.com:443"
-  loki:
-    url: "tbd"
-
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
wir verwenden einen cluster-admin bearer token damit wir grafana ohne einschränkungen verwenden können. die datasource sind somit gesetzt und werden nicht mehr überschrieben.