### PR TITLE
Feature/gpx 448

### DIFF
--- a/infra/gp-cluster-monitoring-config/Chart.yaml
+++ b/infra/gp-cluster-monitoring-config/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.13
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/gp-cluster-monitoring-config/templates/00-cluster-monitoring-config.yaml
+++ b/infra/gp-cluster-monitoring-config/templates/00-cluster-monitoring-config.yaml
@@ -11,6 +11,19 @@ data:
       {{- include "infranodes.enabled" . | nindent 6 }}
     prometheusK8s:
       {{- include "infranodes.enabled" . | nindent 6 }}
+      externalLabels:
+        gepardec_cluster: {{ .Values.clusterMonitoring.prometheusK8s.clusterName }}
+      {{- if .Values.clusterMonitoring.prometheusK8s.remoteWrite.enabled }}
+      remoteWrite:
+        - url: {{ .Values.clusterMonitoring.prometheusK8s.remoteWrite.url }}
+          basicAuth:
+            username:
+              name: hub-remote-write-authentication
+              key: username
+            password:
+              name: hub-remote-write-authentication
+              key: password
+      {{- end }}
       retention: {{ .Values.clusterMonitoring.prometheusK8s.retention }}
       resources:
         requests:

--- a/infra/gp-cluster-monitoring-config/templates/remote-write-authentication.yaml
+++ b/infra/gp-cluster-monitoring-config/templates/remote-write-authentication.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.clusterMonitoring.prometheusK8s.remoteWrite.enabled  -}}
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: hub-remote-write-authentication
+  namespace: openshift-monitoring
+spec:
+  encryptedData:
+    password: {{ .Values.clusterMonitoring.prometheusK8s.remoteWrite.password }}
+  template:
+    data:
+      username: prometheus
+{{- end }}

--- a/infra/gp-cluster-monitoring-config/values.yaml
+++ b/infra/gp-cluster-monitoring-config/values.yaml
@@ -5,6 +5,11 @@ infranodes:
 clusterMonitoring:
   enableUserWorkload: true
   prometheusK8s:
+    clusterName: ""
+    remoteWrite:
+      enabled: true
+      url: https://prometheus.infra.gepaplexx.com/api/v1/receive
+      password: ""  # SealedSecret encrypted password for accessing prometheus remote write endpoint
     retention: 31d
     resources:
       requests:

--- a/infra/gp-hub-monitoring/Chart.yaml
+++ b/infra/gp-hub-monitoring/Chart.yaml
@@ -4,11 +4,11 @@ description: A Helm chart for deploying the Prometheus Monitoring Stack on our H
 
 type: application
 
-version: 0.2.1
+version: 0.2.2
 appVersion: "2.34.0"
 
 dependencies:
   - name: kube-prometheus-stack
     alias: monitoring
-    version: 36.2.1
+    version: 42.0.0
     repository: https://prometheus-community.github.io/helm-charts/

--- a/infra/gp-hub-monitoring/values.yaml
+++ b/infra/gp-hub-monitoring/values.yaml
@@ -30,10 +30,19 @@ monitoring:
         client_secret: "add-me-to-inventory"
 
   prometheus:
+    extraSecret:
+      name: prometheus-auth
+      data:
+       auth: |
+         prometheus:$2b$12$GtjYce9gxCtDepyGgBY5der5KqyZ6g2UDLoCqc19wAFm0dKXGP/Oq
     ingress:
       enabled: true
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
+        # Add Basic Authentication to public ingress. Using the extra secret that has been configured above.
+        nginx.ingress.kubernetes.io/auth-type: basic
+        nginx.ingress.kubernetes.io/auth-secret: prometheus-auth
+        nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required for accessing prometheus via public ingress'
       hosts:
         - prometheus.infra.gepaplexx.com
       tls:

--- a/infra/gp-hub-monitoring/values.yaml
+++ b/infra/gp-hub-monitoring/values.yaml
@@ -33,8 +33,7 @@ monitoring:
     extraSecret:
       name: prometheus-auth
       data:
-       auth: |
-         prometheus:$2b$12$GtjYce9gxCtDepyGgBY5der5KqyZ6g2UDLoCqc19wAFm0dKXGP/Oq
+       auth: ""
     ingress:
       enabled: true
       annotations:

--- a/infra/gp-hub-monitoring/values.yaml
+++ b/infra/gp-hub-monitoring/values.yaml
@@ -1,4 +1,6 @@
 monitoring:
+  defaultRules:
+    create: false
   grafana:
     adminPassword: "changeme"
     ingress:

--- a/infra/gp-hub-monitoring/values.yaml
+++ b/infra/gp-hub-monitoring/values.yaml
@@ -53,7 +53,12 @@ monitoring:
             failureThreshold: 120
             periodSeconds: 30
       enableRemoteWriteReceiver: true
-      retentionSize: 50GiB  # TODO muss erhöht werden, wenn Cluster neu aufgesetzt wird mit mehr Plattenplatz.
+      resources:
+        requests:
+          memory: 6Gi
+          cpu: 3000m
+      retentionSize: 250GiB
+      retention: 30d
       storageSpec:
         volumeClaimTemplate:
           spec:
@@ -61,7 +66,7 @@ monitoring:
             accessModes: [ "ReadWriteMany" ]
             resources:
               requests:
-                storage: 50Gi
+                storage: 300Gi
       ruleSelectorNilUsesHelmValues: false
       serviceMonitorSelectorNilUsesHelmValues: false
       podMonitorSelectorNilUsesHelmValues: false

--- a/infra/gp-hub-monitoring/values.yaml
+++ b/infra/gp-hub-monitoring/values.yaml
@@ -39,6 +39,7 @@ monitoring:
           hosts:
             - prometheus.infra.gepaplexx.com
     prometheusSpec:
+      enableRemoteWriteReceiver: true
       retentionSize: 50GiB  # TODO muss erhöht werden, wenn Cluster neu aufgesetzt wird mit mehr Plattenplatz.
       storageSpec:
         volumeClaimTemplate:

--- a/infra/gp-hub-monitoring/values.yaml
+++ b/infra/gp-hub-monitoring/values.yaml
@@ -41,6 +41,17 @@ monitoring:
           hosts:
             - prometheus.infra.gepaplexx.com
     prometheusSpec:
+      containers: # Patch prometheus startup probe to give the container time to replay the WAL from disk
+        - name: prometheus
+          startupProbe:
+            failureThreshold: 120
+            periodSeconds: 30
+          livenessProbe:
+            failureThreshold: 10
+            periodSeconds: 90
+          readinessProbe:
+            failureThreshold: 120
+            periodSeconds: 30
       enableRemoteWriteReceiver: true
       retentionSize: 50GiB  # TODO muss erhöht werden, wenn Cluster neu aufgesetzt wird mit mehr Plattenplatz.
       storageSpec:


### PR DESCRIPTION
Dieser PR hängt zusammen mit: 
* https://github.com/gepaplexx/inventory-hub/pull/14
* https://github.com/gepaplexx/application-day-x-generator/pull/24
* https://github.com/gepaplexx/gepardec-run-cluster-configuration/pull/40
* https://github.com/gepaplexx/gp-helm-chart-development/pull/142

**PR gp-helm-chart-development: **
In diesem pull request wird einerseits die Cluster Monotoring Konfiguration angepasst, um über remote-write auf die Prometheus Instanz auf dem HUB Cluster die Daten aus dem OpenShift Monitoring (nicht user-workload monitoring) dorthin zu schicken. 
Zusätzlich beinhaltet diese Änderung ein SealedSecret, welches die Authentication zu Prometheus hin steuert. 

Zusätzlich wird in diesem pull request das gp-hub-monitoring helm chart folgendermaßen angepasst/erweitert: 
* Ressourcenanpassungen um mit größeren Datenmengen umgehen zu können. 
* Expose Prometheus über Ingress, damit von den anderen Clustern Daten hingeschickt werden können. 
* Basic Authentication auf Ingress Level, damit die Prometheus Instanz nicht komplett ungesichert im Internet exposed ist. 
* remote-write Endpunkt aktiv gestellt. 
* Anpassungen der Startup-/Readiness-/Livenessprobe, da die größere Datenmenge zu längeren Startup Zeiten führt. 
* Retention konfiguriert auf maximale Datenmenge und Alter der Metriken. 

**PR inventory-hub**
Dieser PR beinhaltet die Konfiguration des Monitoring Stacks auf dem HUB-Cluster. Folgende Änderungen wurden vorgenommen: 
* Entfernen der Prometheus/Thanos Datasources aus dem Inventory, da die Daten jetzt über remote-write in den HUB geschrieben werden. 
* Anpassung der Dashboards - Datasources auf Prometheus geändert und über Labels den konkreten Cluster ausgewählt.
* Konfiguration der Basic Authentication für den Prometheus Ingress (HUB) 

**PR gepardec-run-cluster-configuration**
Neue Properties gesetzt, damit das richtige external label für den Cluster gesetzt wird. SealedSecret encrypted Wert für das Passwort hinzugefügt. 

**PR application-day-x-generator**
Anpassung des Generators, damit im Inventory die Konfiguration für das Passwort beim Prometheus Ingress und der Clustername beim external Label mit reinkommen. 