### PR TITLE
GPX-448 [HUB] Prometheus von Federation auf Remote Write auf Hub Clus…

### DIFF
--- a/infra/gp-hub-monitoring/Chart.yaml
+++ b/infra/gp-hub-monitoring/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying the Prometheus Monitoring Stack on our H
 
 type: application
 
-version: 0.2.2
+version: 0.2.3
 appVersion: "2.34.0"
 
 dependencies:

--- a/infra/gp-hub-monitoring/values.yaml
+++ b/infra/gp-hub-monitoring/values.yaml
@@ -71,7 +71,7 @@ monitoring:
         volumeClaimTemplate:
           spec:
             storageClassName: longhorn
-            accessModes: [ "ReadWriteMany" ]
+            accessModes: [ "ReadWriteOnce" ]
             resources:
               requests:
                 storage: 300Gi


### PR DESCRIPTION
…ter umstellen

Bei RWX stellt Longhorn das PVC über einen integrierten NFS Server zur Verfügung, womit Prometheus nicht klar kommt. Bei RWO provisioniert er das PVC direkt auf der Disk. Die Fehlermeldung in Prometheus taucht durch diese Änderung nicht mehr auf.

Signed-off-by: fhochleitner <felix.hochleitner@outlook.com>