### PR TITLE
GPX-472: Warnhinweis als Kommentar

### DIFF
--- a/infra/gp-cluster-config/Chart.yaml
+++ b/infra/gp-cluster-config/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.11
+version: 1.4.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/gp-cluster-config/templates/11-kubeletconfig.yaml
+++ b/infra/gp-cluster-config/templates/11-kubeletconfig.yaml
@@ -1,3 +1,4 @@
+# ACHTUNG: Änderungen triggern das Drainen aller Master Nodes!!!
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
@@ -31,6 +32,7 @@ spec:
     imageGCHighThresholdPercent: 70
     imageGCLowThresholdPercent: 45
 ---
+# ACHTUNG: Änderungen triggern das Drainen aller Worker und Infra Nodes!!!
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:


### PR DESCRIPTION
Die Nodes werden alle bei Changes in dieser Config gedraint, allerdings tut es das hier hoffentlich nicht, da nur kommentare