### PR TITLE
Feature/gpx 540

### DIFF
--- a/bke-development/gp-cicd-tools/Chart.yaml
+++ b/bke-development/gp-cicd-tools/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.4
+version: 0.7.5
 
 dependencies:
 - name: argo-events

--- a/bke-development/gp-cicd-tools/values.yaml
+++ b/bke-development/gp-cicd-tools/values.yaml
@@ -129,6 +129,51 @@ argo_workflows:
       spec:
         ttlStrategy:
             secondsAfterCompletion: 3600 # delete workflows after 1 hour. they are still available in the archive
+        metrics:
+          prometheus:
+            - name: duration_gauge
+              help: "Duration gauge by name"
+              labels:
+                - key: application
+                  value: "{{ workflow.parameters.reponame }}"
+                - key: branch
+                  value: "{{ workflow.parameters.branch }}"
+                - key: status
+                  value: "{{ workflow.status }}"
+              gauge:
+                realtime: true                  # This metric will be emitted in real time. For more info see: docs/metrics.md
+                value: "{{workflow.duration}}"  # Use {{workflow.duration}} in workflow-level and {{duration}} in template-level
+            - name: failure_count
+              help: "Workflow Failure Counter"
+              labels:
+                - key: application
+                  value: "{{ workflow.parameters.reponame }}"
+                - key: branch
+                  value: "{{ workflow.parameters.branch }}"
+              when: "{{status}} != Succeeded"
+              counter:
+                value: 1
+            - name: success_count
+              help: "Workflow Success Counter"
+              labels:
+                - key: application
+                  value: "{{ workflow.parameters.reponame }}"
+                - key: branch
+                  value: "{{ workflow.parameters.branch }}"
+              when: "{{status}} == Succeeded"
+              counter:
+                value: 1
+            - name: result_count
+              help: "Workflow Result Counter"
+              labels:
+                - key: application
+                  value: "{{ workflow.parameters.reponame }}"
+                - key: branch
+                  value: "{{ workflow.parameters.branch }}"
+                - key: status
+                  value: "{{ workflow.status }}"
+              counter:
+                value: 1
     workflowRestrictions:
       templateReferencing: Strict # only workflows using workflowTemplateRef will be executed
     resources:

--- a/bke-development/gp-cicd-tools/values.yaml
+++ b/bke-development/gp-cicd-tools/values.yaml
@@ -186,6 +186,7 @@ argo_workflows:
 
     metricsConfig:
       enabled: true
+      metricsTTL: 7200 # Metriken werden nach 2 Stunden vom Workflow Controller Endpunkt gelöscht.
     serviceMonitor:
       enabled: true
 

--- a/bke-development/gp-cicd-tools/values.yaml
+++ b/bke-development/gp-cicd-tools/values.yaml
@@ -143,26 +143,6 @@ argo_workflows:
               gauge:
                 realtime: true                  # This metric will be emitted in real time. For more info see: docs/metrics.md
                 value: "{{workflow.duration}}"  # Use {{workflow.duration}} in workflow-level and {{duration}} in template-level
-            - name: failure_count
-              help: "Workflow Failure Counter"
-              labels:
-                - key: application
-                  value: "{{ workflow.parameters.reponame }}"
-                - key: branch
-                  value: "{{ workflow.parameters.branch }}"
-              when: "{{status}} != Succeeded"
-              counter:
-                value: 1
-            - name: success_count
-              help: "Workflow Success Counter"
-              labels:
-                - key: application
-                  value: "{{ workflow.parameters.reponame }}"
-                - key: branch
-                  value: "{{ workflow.parameters.branch }}"
-              when: "{{status}} == Succeeded"
-              counter:
-                value: 1
             - name: result_count
               help: "Workflow Result Counter"
               labels:


### PR DESCRIPTION
Default Workflow-Level Metriken hinzugefügt und TTL für Metriken in Argo Workflows hinzugefügt. 
TTL deswegen, weil die Daten nach 2 Stunden schon lange gescraped sein sollten und nicht mehr unbedingt in Argo abgebildet werden müssen. 