### PR TITLE
Feature/gpx 526

### DIFF
--- a/infra/gp-hashicorp-vault/Chart.yaml
+++ b/infra/gp-hashicorp-vault/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: gp-hashicorp-vault
 description: A Helm chart for Kubernetes, extending the base HC Vault Helm Chart
 type: application
-version: 2.0.7
+version: 2.1.0
 
 dependencies:
 - name: "vault"
-  version: "0.20.1"
+  version: "0.23.0"
   repository: "https://helm.releases.hashicorp.com"

--- a/infra/gp-hashicorp-vault/values.yaml
+++ b/infra/gp-hashicorp-vault/values.yaml
@@ -19,6 +19,7 @@ vault:
       size: '500Mi'
     standalone:
       enabled: false
+    updateStrategyType: RollingUpdate
     readinessProbe:
       path: "/v1/sys/health?standbyok=true&sealedcode=204&uninitcode=204" # show pods as not ready if auto-unseal fails somehow or the node is not initialized yet
     livenessProbe:


### PR DESCRIPTION
Update HC Vault auf aktuellsten Release. 

Zusätzlich musste in der google developer console dem Serviceaccount eine zusätzliche Berechtigung hinzugefügt werden. 