### PR TITLE
Feature/gpx 448

### DIFF
--- a/infra/gp-alertmanager-healthcheck/templates/servicemonitor.yaml
+++ b/infra/gp-alertmanager-healthcheck/templates/servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gp-alertmanager-healthcheck.labels" . | nindent 4 }}
+    instance: primary
   annotations:
     {{- include "gp-alertmanager-healthcheck.annotations" . | nindent 4 }}
 spec:

--- a/infra/gp-awx-monitoring/Chart.yaml
+++ b/infra/gp-awx-monitoring/Chart.yaml
@@ -3,4 +3,4 @@ name: gp-awx-monitoring
 description: A Helm Chart for deploying Monitoring and Alerting Resources for AWX Installation
 
 type: application
-version: 0.1.4
+version: 0.1.5

--- a/infra/gp-awx-monitoring/templates/servicemonitor.yaml
+++ b/infra/gp-awx-monitoring/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     {{- include "gp-awx-monitoring.labels" . | nindent 4 }}
+    instance: primary
   name: awx-servicemonitor
   namespace: {{ .Release.Namespace }}
 spec:

--- a/infra/gp-cluster-monitoring-config/Chart.yaml
+++ b/infra/gp-cluster-monitoring-config/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.4
+version: 1.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/gp-cluster-monitoring-config/values.yaml
+++ b/infra/gp-cluster-monitoring-config/values.yaml
@@ -8,7 +8,7 @@ clusterMonitoring:
     clusterName: ""
     remoteWrite:
       enabled: true
-      url: https://prometheus.infra.gepaplexx.com/api/v1/write
+      url: https://mimir.infra.gepaplexx.com/api/v1/push
       password: ""  # SealedSecret encrypted password for accessing prometheus remote write endpoint
     retention: 31d
     resources:

--- a/infra/gp-hub-logging/values.yaml
+++ b/infra/gp-hub-logging/values.yaml
@@ -1,10 +1,14 @@
 loki:
+  monitoring:
+    selfMonitoring:
+      enabled: true
+    serviceMonitor:
+      labels:
+        instance: primary
   loki:
     auth_enabled: false
   rbac:
     pspEnabled: false
-  selfMonitoring:
-    enabled: true
   gateway:
     enabled: true
     affinity: " "

--- a/infra/gp-hub-monitoring/Chart.yaml
+++ b/infra/gp-hub-monitoring/Chart.yaml
@@ -1,14 +1,19 @@
 apiVersion: v2
 name: gp-hub-monitoring
-description: A Helm chart for deploying the Prometheus Monitoring Stack on our Hub-Cluster
+description: A Helm chart for deploying a Metrics Monitoring Stack on our Hub-Cluster
 
 type: application
 
-version: 0.2.3
-appVersion: "2.34.0"
+version: 0.3.0
 
 dependencies:
-  - name: kube-prometheus-stack
-    alias: monitoring
-    version: 42.0.0
-    repository: https://prometheus-community.github.io/helm-charts/
+  - name: mimir-distributed
+    alias: mimir
+    version: 4.0.0
+    repository: https://grafana.github.io/helm-charts
+  - name: grafana
+    version: 6.50.0
+    repository: https://grafana.github.io/helm-charts
+  - name: kube-state-metrics
+    version: 4.28.0
+    repository: https://prometheus-community.github.io/helm-charts

--- a/infra/gp-hub-monitoring/templates/_helpers.tpl
+++ b/infra/gp-hub-monitoring/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gp-hub-monitoring.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gp-hub-monitoring.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gp-hub-monitoring.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gp-hub-monitoring.labels" -}}
+helm.sh/chart: {{ include "gp-hub-monitoring.chart" . }}
+{{ include "gp-hub-monitoring.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gp-hub-monitoring.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gp-hub-monitoring.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/infra/gp-hub-monitoring/templates/additional-servicemonitors.yaml
+++ b/infra/gp-hub-monitoring/templates/additional-servicemonitors.yaml
@@ -1,0 +1,73 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    instance: primary
+    {{- include "gp-hub-monitoring.labels" . | nindent 4 }}
+  name: kubelet-monitor
+  namespace: kube-system
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 60s
+      metricRelabelings:
+        - action: keep
+          regex: kubelet_cgroup_manager_duration_seconds_count|go_goroutines|kubelet_pod_start_duration_seconds_count|kubelet_runtime_operations_total|kubelet_pleg_relist_duration_seconds_bucket|volume_manager_total_volumes|kubelet_volume_stats_capacity_bytes|container_cpu_usage_seconds_total|container_network_transmit_bytes_total|kubelet_runtime_operations_errors_total|container_network_receive_bytes_total|container_memory_swap|container_network_receive_packets_total|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|kubelet_running_pod_count|node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate|container_memory_working_set_bytes|storage_operation_errors_total|kubelet_pleg_relist_duration_seconds_count|kubelet_running_pods|rest_client_request_duration_seconds_bucket|process_resident_memory_bytes|storage_operation_duration_seconds_count|kubelet_running_containers|kubelet_runtime_operations_duration_seconds_bucket|kubelet_node_config_error|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_running_container_count|kubelet_volume_stats_available_bytes|kubelet_volume_stats_inodes|container_memory_rss|kubelet_pod_worker_duration_seconds_count|kubelet_node_name|kubelet_pleg_relist_interval_seconds_bucket|container_network_receive_packets_dropped_total|kubelet_pod_worker_duration_seconds_bucket|container_start_time_seconds|container_network_transmit_packets_dropped_total|process_cpu_seconds_total|storage_operation_duration_seconds_bucket|container_memory_cache|container_network_transmit_packets_total|kubelet_volume_stats_inodes_used|up|rest_client_requests_total
+          sourceLabels:
+            - __name__
+      port: https-metrics
+      relabelings:
+        - sourceLabels:
+            - __metrics_path__
+          targetLabel: metrics_path
+        - action: replace
+          targetLabel: job
+          replacement: integrations/kubernetes/kubelet
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubelet
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    instance: primary
+    {{- include "gp-hub-monitoring.labels" . | nindent 4 }}
+  name: cadvisor-monitor
+  namespace: kube-system
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      honorTimestamps: false
+      interval: 60s
+      metricRelabelings:
+        - action: keep
+          regex: kubelet_cgroup_manager_duration_seconds_count|go_goroutines|kubelet_pod_start_duration_seconds_count|kubelet_runtime_operations_total|kubelet_pleg_relist_duration_seconds_bucket|volume_manager_total_volumes|kubelet_volume_stats_capacity_bytes|container_cpu_usage_seconds_total|container_network_transmit_bytes_total|kubelet_runtime_operations_errors_total|container_network_receive_bytes_total|container_memory_swap|container_network_receive_packets_total|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|kubelet_running_pod_count|node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate|container_memory_working_set_bytes|storage_operation_errors_total|kubelet_pleg_relist_duration_seconds_count|kubelet_running_pods|rest_client_request_duration_seconds_bucket|process_resident_memory_bytes|storage_operation_duration_seconds_count|kubelet_running_containers|kubelet_runtime_operations_duration_seconds_bucket|kubelet_node_config_error|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_running_container_count|kubelet_volume_stats_available_bytes|kubelet_volume_stats_inodes|container_memory_rss|kubelet_pod_worker_duration_seconds_count|kubelet_node_name|kubelet_pleg_relist_interval_seconds_bucket|container_network_receive_packets_dropped_total|kubelet_pod_worker_duration_seconds_bucket|container_start_time_seconds|container_network_transmit_packets_dropped_total|process_cpu_seconds_total|storage_operation_duration_seconds_bucket|container_memory_cache|container_network_transmit_packets_total|kubelet_volume_stats_inodes_used|up|rest_client_requests_total
+          sourceLabels:
+            - __name__
+      path: /metrics/cadvisor
+      port: https-metrics
+      relabelings:
+        - sourceLabels:
+            - __metrics_path__
+          targetLabel: metrics_path
+        - action: replace
+          targetLabel: job
+          replacement: integrations/kubernetes/cadvisor
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubelet

--- a/infra/gp-hub-monitoring/templates/grafana-agent-rbac.yaml
+++ b/infra/gp-hub-monitoring/templates/grafana-agent-rbac.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-agent
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/cadvisor
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent
+subjects:
+  - kind: ServiceAccount
+    name: grafana-agent
+    namespace: {{ .Release.Namespace }}

--- a/infra/gp-hub-monitoring/templates/grafana-agent.yaml
+++ b/infra/gp-hub-monitoring/templates/grafana-agent.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: GrafanaAgent
+metadata:
+  labels:
+    {{- include "gp-hub-monitoring.labels" . | nindent 4 }}
+  name: metrics-agent
+  namespace: {{ .Release.Namespace }}
+spec:
+  enableConfigReadAPI: false
+  logLevel: info
+  metrics:
+    instanceSelector:
+      matchLabels:
+        {{- include "gp-hub-monitoring.labels" . | nindent 8 }}
+    externalLabels:
+      cluster_discriminator: hub
+  serviceAccountName: grafana-agent

--- a/infra/gp-hub-monitoring/templates/metric-scrapeconfig.yaml
+++ b/infra/gp-hub-monitoring/templates/metric-scrapeconfig.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: MetricsInstance
+metadata:
+  name: metricsinstance
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gp-hub-monitoring.labels" . | nindent 4 }}
+spec:
+  remoteWrite:
+    - url: http://{{ .Release.Name}}-mimir-nginx.{{ .Release.Namespace }}.svc:80/api/v1/push
+  serviceMonitorNamespaceSelector: {}
+  serviceMonitorSelector:
+    matchLabels:
+      instance: primary

--- a/infra/gp-hub-monitoring/values.yaml
+++ b/infra/gp-hub-monitoring/values.yaml
@@ -65,7 +65,7 @@ mimir:
     persistence:
       size: 300Gi
       storageClass: longhorn
-    rootPassword: "" # TODO: in Inventory auslagern
+    rootPassword: "" # will be set from inventory
   nginx:
     enabled: true
     ingress:

--- a/infra/gp-hub-monitoring/values.yaml
+++ b/infra/gp-hub-monitoring/values.yaml
@@ -1,103 +1,159 @@
-monitoring:
-  defaultRules:
-    create: false
-  grafana:
-    adminPassword: "changeme"
-    ingress:
-      enabled: true
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt
-        nginx.ingress.kubernetes.io/rewrite-target: /
-      hosts:
-        - grafana.infra.gepaplexx.com
-      tls:
-        - secretName: grafana-general-tls
-          hosts:
-            - grafana.infra.gepaplexx.com
-    grafana.ini:
-      server:
-        domain: grafana.infra.gepaplexx.com
-        root_url: "https://grafana.infra.gepaplexx.com"
-      auth.github:
-        enabled: true
-        allow_sign_up: true
-        scopes: user:email,read:org
-        auth_url: https://github.com/login/oauth/authorize
-        token_url: https://github.com/login/oauth/access_token
-        api_url: https://api.github.com/user
-        allowed_organizations: gepaplexx
-        client_id: "add-me-to-inventory"
-        client_secret: "add-me-to-inventory"
-
-  prometheus:
-    extraSecret:
-      name: prometheus-auth
-      data:
-       auth: ""
-    ingress:
-      enabled: true
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt
-        # Add Basic Authentication to public ingress. Using the extra secret that has been configured above.
-        nginx.ingress.kubernetes.io/auth-type: basic
-        nginx.ingress.kubernetes.io/auth-secret: prometheus-auth
-        nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required for accessing prometheus via public ingress'
-      hosts:
-        - prometheus.infra.gepaplexx.com
-      tls:
-        - secretName: prometheus-general-tls
-          hosts:
-            - prometheus.infra.gepaplexx.com
-    prometheusSpec:
-      containers: # Patch prometheus startup probe to give the container time to replay the WAL from disk
-        - name: prometheus
-          startupProbe:
-            failureThreshold: 120
-            periodSeconds: 30
-          livenessProbe:
-            failureThreshold: 10
-            periodSeconds: 90
-          readinessProbe:
-            failureThreshold: 120
-            periodSeconds: 30
-      enableRemoteWriteReceiver: true
-      resources:
-        requests:
-          memory: 6Gi
-          cpu: 3000m
-      retentionSize: 250GiB
-      retention: 30d
-      storageSpec:
-        volumeClaimTemplate:
-          spec:
-            storageClassName: longhorn
-            accessModes: [ "ReadWriteOnce" ]
-            resources:
-              requests:
-                storage: 300Gi
-      ruleSelectorNilUsesHelmValues: false
-      serviceMonitorSelectorNilUsesHelmValues: false
-      podMonitorSelectorNilUsesHelmValues: false
-      probeSelectorNilUsesHelmValues: false
-      additionalServiceMonitors:
-        namespaceSelector:
-          any: "true"
+mimir:
+  runtimeConfig:
+    overrides:
+      anonymous:
+        max_global_series_per_user: 0
+        max_label_names_per_series: 60
+        ingestion_rate: 200000
+        ingestion_burst_size: 500000
+        compactor_blocks_retention_period: 15d  # initial test to find out storage requirements
+        out_of_order_time_window: 12h
   alertmanager:
-    ingress:
+    persistentVolume:
+      size: 1Gi
+    storageClass: longhorn
+  distributor:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 1024Mi
+  ingester:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 1024Mi
+    persistentVolume:
+      size: 80Gi
+      storageClass: longhorn
+    zoneAwareReplication:
       enabled: false
+  querier:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 1024Mi
+  queryFrontend:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 1024Mi
+  store_gateway:
+    zoneAwareReplication:
+      enabled: false
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+    persistentVolume:
+      size: 3Gi
+      storageClass: longhorn
+  compactor:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 1024Mi
+    persistentVolume:
+      size: 10Gi
+      storageClass: longhorn
+  rollout_operator:
+    enabled: false
+  minio:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 1024Mi
+    persistence:
+      size: 300Gi
+      storageClass: longhorn
+    rootPassword: "" # TODO: in Inventory auslagern
+  nginx:
+    enabled: true
+    ingress:
+      enabled: true
+      ingressClassName: public
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
+        nginx.org/client-max-body-size: "0"
       hosts:
-        - alertmanager.infra.gepaplexx.com
+        - host: mimir.infra.gepaplexx.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
       tls:
-        - secretName: alertmanager-tls
+        - secretName: mimir-nginx-tls
           hosts:
-            - alertmanager.infra.gepaplexx.com
+            - mimir.infra.gepaplexx.com
+    basicAuth:
+      enabled: true
+      username: "prometheus"
+      password: "" # Value gets set from inventory
+  metaMonitoring:
+    serviceMonitor:
+      enabled: true
+      labels:
+        instance: primary
+    grafanaAgent:
+      logs:
+        enabled: false
+      metrics:
+        scrapeK8s:
+          enabled: true
+          kubeStateMetrics:
+            namespace: kube-system
+            labelSelectors:
+              app.kubernetes.io/name: kube-state-metrics
+grafana:
+  rbac:
+    pspEnabled: false # PSP are deprecated - removed in kubernetes 1.25
+  ingress:
+    enabled: true
+    ingressClassName: public
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+    hosts:
+      - grafana.infra.gepaplexx.com
+    tls:
+        - secretName: grafana-tls
+          hosts:
+          - grafana.infra.gepaplexx.com
+  persistence:
+    enabled: true
+    type: pvc
+    accessModes: [ "ReadWriteOnce" ]
+    size: 2Gi
+    storageClassName: longhorn
+  adminUser: "admin"
+  adminPassword: "" # value gets set from inventory
+  grafana.ini:
+    server:
+      domain: grafana.infra.gepaplexx.com
+      root_url: "https://grafana.infra.gepaplexx.com"
+    auth.github:
+      enabled: true
+      allow_sign_up: true
+      scopes: user:email,read:org
+      auth_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+      api_url: https://api.github.com/user
+      allowed_organizations: gepaplexx
+      client_id: "" # Value gets set from inventory
+      client_secret: "" # Value gets set from inventory
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+      - name: Mimir
+        uid: mimir
+        type: prometheus
+        # url is in the format of {{ .Release.Name }}-mimir-nginx.{{ .Release.Namespace }}.svc.cluster:80/prometheus
+        url: http://monitoring-stack-mimir-nginx.hub-monitoring.svc:80/prometheus
+        access: proxy
+        isDefault: true
+        editable: true
+        jsonData:
+          httpMethod: POST
+          prometheusType: Mimir
+          prometheusVersion: "2.4.0"
 
-  kubeScheduler:
-    enabled: false # wird in microk8s anders gehandhabt
-  kubeControllerManager:
-    enabled: false # wird in microk8s anders gehandhabt
-  kubeProxy:
-    enabled: false # wird in microk8s anders gehandhabt
-
+kube-state-metrics:
+  namespaceOverride: "kube-system"


### PR DESCRIPTION
Umstellung von Prometheus auf Mimir als TSDB für Metriken auf unserem HUB-Cluster. 
Hierbei wurden folgende Änderungen vorgenommen: 
* Entfernen des "monitoring-stack-k8s-prometheus" Charts
* Einbinden folgender Charts: 
  * Grafana - Standalone Deployment von Grafana. Konfiguration der Mimir Default Datasource. Einbindung der Dashboards für den Raspberry Pi über das "inventory-hub" Repository
  *  Mimir - Standalone Deployment von Mimir als TSDB. Enthält zusätzlich ServiceMonitore um die eigenen Komponenten zu überwachen. 
  * Kube-State-Metrics - Deployment zum bereitstellen von Kubelet und cAdvisor Metriken im Cluster 
* Zusätzliche Clusterrole und Clusterrolebinding für Grafana Serviceaccount, um kubelet und cAdvisor Metriken erfassen und scrapen zu können. 
* Metricsinstance um die Metriken  im Cluster an Mimir zu schicken. Wichtig hierbei: jeder Servicemonitor am Hub benötigt das Label "instance: primary", damit er von der Metricsinstance abgegriffen wird. 

Dazugehörige PRs: 
* https://github.com/gepaplexx/inventory-hub/pull/19 - Anpassungen im Inventory aufgrund der geänderten Struktur in den Values
* https://github.com/gepaplexx/gepardec-run-cluster-configuration/pull/55 - Aktivierung des Syncs der Monitoring Instance