### PR TITLE
Tune prometheus remote write

### DIFF
--- a/infra/gp-cluster-monitoring-config/Chart.yaml
+++ b/infra/gp-cluster-monitoring-config/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.5
+version: 1.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/gp-cluster-monitoring-config/templates/00-cluster-monitoring-config.yaml
+++ b/infra/gp-cluster-monitoring-config/templates/00-cluster-monitoring-config.yaml
@@ -16,6 +16,10 @@ data:
       {{- if .Values.clusterMonitoring.prometheusK8s.remoteWrite.enabled }}
       remoteWrite:
         - url: {{ .Values.clusterMonitoring.prometheusK8s.remoteWrite.url }}
+          remoteTimeout: 60s
+          queueConfig:
+            maxSamplesPerSend: 8000
+            maxShards: 30
           basicAuth:
             username:
               name: hub-remote-write-authentication
@@ -23,6 +27,11 @@ data:
             password:
               name: hub-remote-write-authentication
               key: password
+          writeRelabelConfigs:
+            - sourceLabels:
+                - "__name__"
+              regex: "apiserver_request_slo_duration_seconds_bucket|apiserver_request_duration_seconds_bucket|etcd_request_duration_seconds_bucket|apiserver_response_sizes_bucket|rest_client_request_duration_seconds_bucket|rest_client_rate_limiter_duration_seconds_bucket"
+              action: "drop"
       {{- end }}
       retention: {{ .Values.clusterMonitoring.prometheusK8s.retention }}
       resources:


### PR DESCRIPTION
- raise remote_timeout from 30 to 60 seconds so less deadline exceeded happens
- send more samples per send from 500 to 8000
- lower max shard from 200 to 30 which makes it much more stable
- do not send selected metrics with very high cardinality