### PR TITLE
GPX-565: Added label to generated external secret alert-manager-main

### DIFF
--- a/infra/gp-cluster-monitoring-config/Chart.yaml
+++ b/infra/gp-cluster-monitoring-config/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/gp-cluster-monitoring-config/templates/08-alertmanager-config-external-secret.yaml
+++ b/infra/gp-cluster-monitoring-config/templates/08-alertmanager-config-external-secret.yaml
@@ -21,6 +21,12 @@ spec:
     creationPolicy: Merge
     deletionPolicy: Retain
     name: alertmanager-main
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          app.kubernetes.io/managed-by: alertmanager-config-global-external-secret
+
 ---
 kind: ServiceAccount
 apiVersion: v1


### PR DESCRIPTION
A pre-defined label is important because per default eso will apply its own labels which uses “instance” which therefore ArgoCD uses to determine if it should manage a resource. In this case, ArgoCD pruned the generated secret. For not already existing secrets, please consider using an owner reference.