### PR TITLE
Updated idle connection limit to 50

### DIFF
--- a/bke-development/gp-cicd-tools/values.yaml
+++ b/bke-development/gp-cicd-tools/values.yaml
@@ -174,6 +174,8 @@ argo_workflows:
       archive: true
       nodeStatusOffLoad: true # if true node status is only saved to the persistence DB to avoid the 1MB limit in etcd
       archiveTTL: 120d
+      connectionPool:
+        maxIdleConns: 50
       postgresql:
         host: *argo_workflows_db_host
         port: 5432

--- a/infra/gp-cluster-update-checker/Chart.yaml
+++ b/infra/gp-cluster-update-checker/Chart.yaml
@@ -20,4 +20,4 @@ version: 1.2.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 1.16.1


### PR DESCRIPTION
Unser Postgresql hat ein gesamtes Connection Limit auf 100 (default), per default hat die Argo Workflow denselben Wert für Limits auf seine idle connection.

Daher limit runterschalten, da Postgresql unabhängig der idle Connections von Workflows noch andere Connections verwaltet und daher zu viele Connections erhält.