### PR TITLE
Hotfix: Login über "Login via OpenShift" schlägt fehl mit openshift-gitops >= 1.8.0

### DIFF
--- a/bke-development/gp-cicd-tools/Chart.yaml
+++ b/bke-development/gp-cicd-tools/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.2
+version: 0.18.0
 
 dependencies:
 - name: argo-events

--- a/bke-development/gp-cicd-tools/templates/argocd-instance.yaml
+++ b/bke-development/gp-cicd-tools/templates/argocd-instance.yaml
@@ -16,7 +16,7 @@ spec:
         cpu: {{ .Values.argocd.applicationset.resources.requests.cpu }}
         memory: {{ .Values.argocd.applicationset.resources.requests.memory }}
   controller:
-    processors: {}
+    processors: { }
     resources:
       limits:
         cpu: {{ .Values.argocd.controller.resources.limits.cpu }}
@@ -24,21 +24,23 @@ spec:
       requests:
         cpu: {{ .Values.argocd.controller.resources.requests.cpu }}
         memory: {{ .Values.argocd.controller.resources.requests.memory }}
-    sharding: {}
-  dex:
-    openShiftOAuth: true
-    resources:
-      limits:
-        cpu: {{ .Values.argocd.dex.resources.limits.cpu }}
-        memory: {{ .Values.argocd.dex.resources.limits.memory }}
-      requests:
-        cpu: {{ .Values.argocd.dex.resources.requests.cpu }}
-        memory: {{ .Values.argocd.dex.resources.requests.memory }}
+    sharding: { }
+  sso:
+    provider: dex
+    dex:
+      openShiftOAuth: true
+      resources:
+        limits:
+          cpu: {{ .Values.argocd.dex.resources.limits.cpu }}
+          memory: {{ .Values.argocd.dex.resources.limits.memory }}
+        requests:
+          cpu: {{ .Values.argocd.dex.resources.requests.cpu }}
+          memory: {{ .Values.argocd.dex.resources.requests.memory }}
   grafana:
     enabled: false
   ha:
     enabled: false
-  initialSSHKnownHosts: {}
+  initialSSHKnownHosts: { }
   prometheus:
     enabled: false
   rbac:


### PR DESCRIPTION
fix argocd login issue über "Login via OpenShift"

siehe: https://issues.redhat.com/browse/GITOPS-2761