### PR TITLE
hotfix/change external secret route to vault

### DIFF
--- a/infra/gp-external-secrets-configuration/Chart.yaml
+++ b/infra/gp-external-secrets-configuration/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: gp-external-secrets-configuration
 description: A Helm chart for Kubernetes containing configuration for the External Secrets Operator
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/infra/gp-external-secrets-configuration/templates/admin-cicd-cluster-store.yaml
+++ b/infra/gp-external-secrets-configuration/templates/admin-cicd-cluster-store.yaml
@@ -12,5 +12,5 @@ spec:
           serviceAccountRef:
             name: dev-admin-sa
       path: development/admin/
-      server: 'http://vault-active.gp-vault.svc.cluster.local:8200'
+      server: 'https://vault-ui-gp-vault.apps.c-gepa-play.gepa.vshnmanaged.net/'
       version: v2

--- a/infra/gp-external-secrets-configuration/templates/cicd-project-cluster-store.yaml
+++ b/infra/gp-external-secrets-configuration/templates/cicd-project-cluster-store.yaml
@@ -12,5 +12,5 @@ spec:
           serviceAccountRef:
             name: operate-workflow-sa
       path: development/cicd/
-      server: 'http://vault-active.gp-vault.svc.cluster.local:8200'
+      server: 'https://vault-ui-gp-vault.apps.c-gepa-play.gepa.vshnmanaged.net/'
       version: v2

--- a/infra/gp-external-secrets-configuration/templates/internal-cluster-store.yaml
+++ b/infra/gp-external-secrets-configuration/templates/internal-cluster-store.yaml
@@ -12,5 +12,5 @@ spec:
           serviceAccountRef:
             name: admin-config-reader
       path: cluster/config/
-      server: 'http://vault-active.gp-vault.svc.cluster.local:8200'
+      server: 'https://vault-ui-gp-vault.apps.c-gepa-play.gepa.vshnmanaged.net/'
       version: v2


### PR DESCRIPTION
Die Route vom ClusterSecretStore zum Vault läuft jetzt über die nach außen hin geöffnete Route 