### PR TITLE
bump: Grafana v9 -> v10

### DIFF
--- a/infra/gp-grafana-instance/Chart.yaml
+++ b/infra/gp-grafana-instance/Chart.yaml
@@ -3,4 +3,4 @@ name: gp-grafana-instance
 description: A Helm chart for deploying Grafana on OpenShift
 
 type: application
-version: 0.5.0
+version: 0.6.0

--- a/infra/gp-grafana-instance/templates/grafana-crd.yaml
+++ b/infra/gp-grafana-instance/templates/grafana-crd.yaml
@@ -37,7 +37,7 @@ spec:
       api_url: >-
         {{ .Values.sso.keycloak.realmUrl }}/protocol/openid-connect/userinfo
       role_attribute_path: >-
-        contains(groups[*], '{{ .Values.auth.adminGroups }}') && 'Admin' || contains(groups[*],
+        contains(groups[*], '{{ .Values.auth.adminGroups }}') && 'GrafanaAdmin' || contains(groups[*],
         '{{ .Values.auth.editorGroups }}') && 'Editor' || 'Viewer'
       auth_url: >-
         {{ .Values.sso.keycloak.realmUrl }}/protocol/openid-connect/auth
@@ -52,7 +52,7 @@ spec:
     security:
       admin_user: {{ default "admin" .Values.auth.admin.user }}
     feature_toggles:
-      enable: accessTokenExpirationCheck autoMigrateOldPanels correlations publicDashboards nestedFolders enableDatagridEditing
+      enable: accessTokenExpirationCheck autoMigrateOldPanels correlations publicDashboards nestedFolders
   dashboardLabelSelector:
     - matchExpressions:
         - key: dashboard

--- a/infra/gp-grafana-instance/templates/grafana-crd.yaml
+++ b/infra/gp-grafana-instance/templates/grafana-crd.yaml
@@ -41,7 +41,7 @@ spec:
         '{{ .Values.auth.editorGroups }}') && 'Editor' || 'Viewer'
       auth_url: >-
         {{ .Values.sso.keycloak.realmUrl }}/protocol/openid-connect/auth
-      scopes: openid profile
+      scopes: openid profile offline_access
     auth.anonymous:
       enabled: false
     log:
@@ -51,6 +51,8 @@ spec:
       enabled: true
     security:
       admin_user: {{ default "admin" .Values.auth.admin.user }}
+    feature_toggles:
+      enable: accessTokenExpirationCheck autoMigrateOldPanels correlations publicDashboards nestedFolders enableDatagridEditing
   dashboardLabelSelector:
     - matchExpressions:
         - key: dashboard

--- a/infra/gp-grafana-instance/values.yaml
+++ b/infra/gp-grafana-instance/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 grafana:
-  version: docker.io/grafana/grafana:9.5.2-ubuntu
+  version: docker.io/grafana/grafana:10.0.0-ubuntu
 ingress:
   hostname: grafana.apps.example.gepaplexx.com
 auth:


### PR DESCRIPTION
+ Bump Grafana version from v9 to v10

+ added offline access scope for refresh tokens

+ added feature toggles including refresh token, correlations, editing data grids, nested folder, public Dashboards and auto migration of old panels
