### PR TITLE
Bug(GPX-722): Vault Backuptester Stuck. 

### DIFF
--- a/infra/gp-hashicorp-vault/Chart.yaml
+++ b/infra/gp-hashicorp-vault/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gp-hashicorp-vault
 description: A Helm chart for Kubernetes, extending the base HC Vault Helm Chart
 type: application
-version: 2.3.7
-appVersion: 1.13.2
+version: 2.3.8
+appVersion: 1.14.0
 
 dependencies:
 - name: "vault"

--- a/infra/gp-hashicorp-vault/templates/BackupTestJob.yaml
+++ b/infra/gp-hashicorp-vault/templates/BackupTestJob.yaml
@@ -55,9 +55,9 @@ spec:
                   value: /data
               command: ["/bin/sh", "-ec"]
               args:
-                - echo "Creating backup"
+                - echo "Testing if vault backup got created correctly and can be restored"
                   && vault server -config=/vault/config/config.hcl
-                  && sleep 10
+                  & sleep 10
                   && ROOT_TOKEN_FRAGMENT=$(vault operator init -format=json | grep root_token)
                   && ROOT_TOKEN=$(echo ${ROOT_TOKEN_FRAGMENT:17:-1})
                   && vault login $ROOT_TOKEN
@@ -67,7 +67,7 @@ spec:
                   && export VAULT_TOKEN=$(vault write -field=token auth/kubernetes/login role="backup-tester" jwt=$(cat /run/secrets/kubernetes.io/serviceaccount/token))
                   && if [ -z "$(vault auth list | grep oidc)" ]; then echo "oidc auth not found in backup!"; exit 1; fi
                   && if [ -z "$(vault secrets list | grep cluster/config/)" ]; then echo "cluster/config/ secret store not found in backup!"; exit 1; fi
-                  && echo "Backup created"
+                  && echo "Backup & restore successfully"
               resources:
                 requests:
                   memory: {{ .Values.backup.testingResources.requests.memory }}


### PR DESCRIPTION
vault cannot autounseal if it never has been initialized. Therefore vault server command needs to run in background in order for "vault operator init" to unseal and initialize empty vault before restoring the created backup.