### PR TITLE
Support vanilla k8s, PodSecurityContext and topologySpreadConstraints

### DIFF
--- a/infra/gp-multena/Chart.yaml
+++ b/infra/gp-multena/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.4
+version: 1.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/gp-multena/templates/deployment.yaml
+++ b/infra/gp-multena/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "gp-multena.serviceAccountName" . }}
+      {{- with .Values.proxy.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: multena-proxy
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/infra/gp-multena/templates/deployment.yaml
+++ b/infra/gp-multena/templates/deployment.yaml
@@ -59,8 +59,10 @@ spec:
             timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.openshift }}
             - mountPath: /etc/secrets/ca/
               name: openshift-service-ca
+            {{- end }}
             - mountPath: /etc/config/config/
               name: multena-config
             {{- if eq .Values.proxy.web.labelStoreKind "configmap" }}
@@ -80,9 +82,11 @@ spec:
               name: multena-thanos-tls-secret
             {{- end }}
       volumes:
+          {{- if .Values.openshift }}
         - configMap:
             name: openshift-service-ca.crt
           name: openshift-service-ca
+          {{- end }}
         - configMap:
             name: {{ include "gp-multena.name" . }}-config
           name: multena-config

--- a/infra/gp-multena/templates/deployment.yaml
+++ b/infra/gp-multena/templates/deployment.yaml
@@ -29,6 +29,15 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.proxy.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range . }}
+        - {{- toYaml . | nindent 10 }}
+          labelSelector:
+            matchLabels:
+              {{- include "gp-multena.selectorLabels" $ | nindent 14 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: multena-proxy
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/infra/gp-multena/templates/rbac-collector/deployment.yaml
+++ b/infra/gp-multena/templates/rbac-collector/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "gp-multena-rbac-collector.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "gp-multena-rbac-collector.name" . }}-sa
+      {{- with .Values.collector.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: rbac-collector
           image: {{ .Values.collector.image.name }}:{{ .Values.collector.image.tag }}

--- a/infra/gp-multena/values.yaml
+++ b/infra/gp-multena/values.yaml
@@ -1,3 +1,5 @@
+openshift: true # openshift or vanilla kubernetes?
+
 proxy:
   log:
     level: 1 # 0 - debug, 1 - info, 2 - warn, 3 - error, -1 trace (exposes sensitive data)

--- a/infra/gp-multena/values.yaml
+++ b/infra/gp-multena/values.yaml
@@ -30,7 +30,7 @@ proxy:
     jwksCertUrl: https://sso.play.run.gepardec.com/realms/internal/protocol/openid-connect/certs
     tlsVerifySkip: false # skip tls verification very insecurely!!!
   securityContext: {}
-
+  topologySpreadConstraints: []
 
 GrafanaOperatorDatasources:
   thanos: true

--- a/infra/gp-multena/values.yaml
+++ b/infra/gp-multena/values.yaml
@@ -29,6 +29,8 @@ proxy:
     oauthGroupName: "groups"
     jwksCertUrl: https://sso.play.run.gepardec.com/realms/internal/protocol/openid-connect/certs
     tlsVerifySkip: false # skip tls verification very insecurely!!!
+  securityContext: {}
+
 
 GrafanaOperatorDatasources:
   thanos: true
@@ -56,6 +58,7 @@ collector:
       cpu: 5m
     limits:
       memory: 75Mi
+  securityContext: {}
 
 service:
   webPort: 8080


### PR DESCRIPTION
We are running Multena in a plain k8s environment, thus we need a way to disable volume mounts specific to Openshift envs. Additionally, I have added the option to set PodSecurityContext on proxy and collector pods. And finally, I have added support for defining topologySpreadConstraints for the proxy pods.